### PR TITLE
Modify response of GET /v1/tags/main/{id}/evaluations response

### DIFF
--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/controller/EvaluationController.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/controller/EvaluationController.kt
@@ -49,7 +49,7 @@ class EvaluationController(
         @PathVariable(value = "id") tagId: Long,
         @RequestParam("cursor") cursor: String?,
         @RequestAttribute(value = "UserId") userId: String,
-    ): CursorPaginationResponse<LectureEvaluationWithSemesterAndTitleDto> {
+    ): CursorPaginationResponse<LectureEvaluationWithLectureDto> {
         return evaluationService.getMainTagEvaluations(userId, tagId, cursor)
     }
 

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/dto/EvaluationResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/dto/EvaluationResponse.kt
@@ -148,7 +148,7 @@ data class LectureEvaluationWithSemesterDto(
     val isReportable: Boolean,
 )
 
-data class LectureEvaluationWithSemesterAndTitleDto(
+data class LectureEvaluationWithLectureDto(
     val id: Long,
 
     @JsonProperty("user_id")
@@ -185,17 +185,21 @@ data class LectureEvaluationWithSemesterAndTitleDto(
 
     val semester: Int,
 
-    @JsonProperty("lecture_id")
-    val lectureId: Long,
-
-    @JsonProperty("lecture_title")
-    val lectureTitle: String,
+    val lecture: SimpleLectureDto,
 
     @JsonProperty("is_modifiable")
     val isModifiable: Boolean,
 
     @JsonProperty("is_reportable")
     val isReportable: Boolean,
+)
+
+data class SimpleLectureDto(
+    val id: Long,
+
+    val title: String,
+
+    val instructor: String,
 )
 
 data class LectureEvaluationsResponse(

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/model/LectureEvaluation.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/model/LectureEvaluation.kt
@@ -83,4 +83,6 @@ data class LectureEvaluationWithLecture(
     val lectureId: Long? = null,
 
     val lectureTitle: String? = null,
+
+    val lectureInstructor: String? = null,
 )

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/repository/LectureEvaluationRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/repository/LectureEvaluationRepository.kt
@@ -18,7 +18,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, cast(null as string)) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, cast(null as string), cast(null as string)) 
         from LectureEvaluation le inner join le.semesterLecture sl where sl.lecture.id = :lectureId and le.isHidden = false and le.userId <> :userId 
         order by sl.year desc, sl.semester desc, le.id desc
     """
@@ -28,7 +28,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select 
         le.id as id, le.user_id as userId, le.content as content, le.grade_satisfaction as gradeSatisfaction, le.teaching_skill as teachingSkill, le.gains as gains, le.life_balance as lifeBalance, le.rating as rating, 
-        le.like_count as likeCount, le.dislike_count as dislikeCount, le.is_hidden as isHidden, le.is_reported as isReported, sl.year as year, sl.semester as semester, sl.lecture_id as lectureId, cast(null as char) as lectureTitle 
+        le.like_count as likeCount, le.dislike_count as dislikeCount, le.is_hidden as isHidden, le.is_reported as isReported, sl.year as year, sl.semester as semester, sl.lecture_id as lectureId, cast(null as char) as lectureTitle, cast(null as char) as lectureInstructor 
         from lecture_evaluation le inner join semester_lecture sl on le.semester_lecture_id = sl.id where sl.lecture_id = :lectureId and le.is_hidden = false and le.user_id <> :userId 
         and (sl.year, sl.semester, le.id) < (:cursorYear, :cursorSemester, :cursorId)
         order by sl.year desc, sl.semester desc, le.id desc
@@ -48,7 +48,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false
         order by le.id desc
     """
@@ -58,7 +58,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false
         and le.id < :cursorId 
         order by le.id desc
@@ -78,7 +78,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
@@ -92,7 +92,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
@@ -120,7 +120,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
@@ -134,7 +134,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
@@ -162,7 +162,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
@@ -176,7 +176,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
@@ -204,7 +204,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
@@ -218,7 +218,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
@@ -246,7 +246,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
-        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, cast(null as string)) 
+        le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, cast(null as string), cast(null as string)) 
         from LectureEvaluation le inner join le.semesterLecture sl where sl.lecture.id = :lectureId and le.userId = :userId and le.isHidden = false 
         order by sl.year desc, sl.semester desc, le.id desc
     """

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/service/EvaluationService.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/service/EvaluationService.kt
@@ -36,6 +36,7 @@ class EvaluationService(
 
     private val defaultPageSize = 3
 
+    @CacheEvict("tag-recent-evaluations")
     fun createEvaluation(
         userId: String,
         semesterLectureId: Long,

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/service/EvaluationService.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/service/EvaluationService.kt
@@ -128,6 +128,7 @@ class EvaluationService(
                     semester = it["semester"] as Int,
                     lectureId = (it["lectureId"] as BigInteger).toLong(),
                     lectureTitle = it["lectureTitle"] as String?,
+                    lectureInstructor = it["lectureInstructor"] as String?,
                 )
             }
         } ?: lectureEvaluationRepository.findByLectureIdOrderByDesc(lectureId, userId, pageable)
@@ -162,7 +163,7 @@ class EvaluationService(
         userId: String,
         tagId: Long,
         cursor: String?,
-    ): CursorPaginationResponse<LectureEvaluationWithSemesterAndTitleDto> {
+    ): CursorPaginationResponse<LectureEvaluationWithLectureDto> {
         val tag = tagRepository.findByIdOrNull(tagId) ?: throw TagNotFoundException
 
         val pageable = PageRequest.of(0, defaultPageSize)
@@ -185,7 +186,7 @@ class EvaluationService(
 
         return CursorPaginationResponse(
             content = cursorPaginationForLectureEvaluationWithLectureDto.lectureEvaluationsWithLecture.map {
-                genLectureEvaluationWithSemesterAndTitleDto(userId, it)
+                genLectureEvaluationWithLectureDto(userId, it)
             },
             cursor = cursorPaginationForLectureEvaluationWithLectureDto.cursor,
             size = defaultPageSize,
@@ -375,11 +376,11 @@ class EvaluationService(
             isReportable = lectureEvaluationWithLecture.userId != userId,
         )
 
-    private fun genLectureEvaluationWithSemesterAndTitleDto(
+    private fun genLectureEvaluationWithLectureDto(
         userId: String,
         lectureEvaluationWithLecture: LectureEvaluationWithLecture,
-    ): LectureEvaluationWithSemesterAndTitleDto =
-        LectureEvaluationWithSemesterAndTitleDto(
+    ): LectureEvaluationWithLectureDto =
+        LectureEvaluationWithLectureDto(
             id = lectureEvaluationWithLecture.id!!,
             userId = lectureEvaluationWithLecture.userId!!,
             content = lectureEvaluationWithLecture.content!!,
@@ -394,8 +395,11 @@ class EvaluationService(
             isReported = lectureEvaluationWithLecture.isReported!!,
             year = lectureEvaluationWithLecture.year!!,
             semester = lectureEvaluationWithLecture.semester!!,
-            lectureId = lectureEvaluationWithLecture.lectureId!!,
-            lectureTitle = lectureEvaluationWithLecture.lectureTitle!!,
+            lecture = SimpleLectureDto(
+                id = lectureEvaluationWithLecture.lectureId!!,
+                title = lectureEvaluationWithLecture.lectureTitle!!,
+                instructor = lectureEvaluationWithLecture.lectureInstructor!!,
+            ),
             isModifiable = lectureEvaluationWithLecture.userId == userId,
             isReportable = lectureEvaluationWithLecture.userId != userId,
         )

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/service/EvaluationService.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/service/EvaluationService.kt
@@ -36,7 +36,7 @@ class EvaluationService(
 
     private val defaultPageSize = 3
 
-    @CacheEvict("tag-recent-evaluations")
+    @CacheEvict("tag-recent-evaluations", allEntries = true)
     fun createEvaluation(
         userId: String,
         semesterLectureId: Long,


### PR DESCRIPTION
related threads: https://wafflestudio.slack.com/archives/C011A82B6NM/p1643520476015449

# Major Changes
## 1. Modify response of GET /v1/tags/main/{id}/evaluations response
### before
```
{
  "content": [
    {
      "id": 0,
      "user_id": "string",
      "content": "string",
      "grade_satisfaction": 0,
      "teaching_skill": 0,
      "gains": 0,
      "life_balance": 0,
      "rating": 0,
      "like_count": 0,
      "dislike_count": 0,
      "is_hidden": true,
      "is_reported": true,
      "year": 0,
      "semester": 0,
      "lecture_id": 0,
      "lecture_title": "string",
      "is_modifiable": true,
      "is_reportable": true
    }
  ],
  "cursor": "string",
  "size": 0,
  "last": true,
  "total_count": 0
}
```

### after
```
{
  "content": [
    {
      "id": 0,
      "user_id": "string",
      "content": "string",
      "grade_satisfaction": 0,
      "teaching_skill": 0,
      "gains": 0,
      "life_balance": 0,
      "rating": 0,
      "like_count": 0,
      "dislike_count": 0,
      "is_hidden": true,
      "is_reported": true,
      "year": 0,
      "semester": 0,
      "lecture": {
        "id": 0,
        "title": "string",
        "instructor": "string"
      },
      "is_modifiable": true,
      "is_reportable": true
    }
  ],
  "cursor": "string",
  "size": 0,
  "last": true,
  "total_count": 0
}
```

## 2. 강의평 생성 시, "tag-recent-evaluations" cache 에 대한 evict
