### PR TITLE
Update Swagger

### DIFF
--- a/src/main/kotlin/com/wafflestudio/snuttev/config/SwaggerConfig.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/config/SwaggerConfig.kt
@@ -23,12 +23,10 @@ class SwaggerConfig {
                     Responses 의 "user_id" 는 /ev-service/* 를 routing하는 환경에서 실제로는 아래와 같은 schema로 변환됩니다.
                     
                     "user": {
-                        "is_admin": false,
-                        "reg_date": "2022-01-23T00:00:00.000Z",
-                        "notification_checked_at": "2021-07-24T08:28:34.804Z",
-                        "email": "bdv111@wafflestudio.com",
-                        "local_id": "bdv111",
-                        "fb_name": null
+                        "id": "string",
+                        "email": "string", (nullable)
+                        "local_id": "string", (nullable)
+                        "fb_name": "string" (nullable)
                     }
                 """)
                 .version("v0.0.1")

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/common/model/BaseEntity.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/common/model/BaseEntity.kt
@@ -11,11 +11,11 @@ open class BaseEntity (
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     open val id: Long? = null,
 
-    @Column(nullable = false)
+    @Column(name = "created_at", nullable = false)
     open val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @field:UpdateTimestamp
-    @Column(nullable = false)
+    @Column(name = "updated_at", nullable = false)
     open val updatedAt: LocalDateTime? = LocalDateTime.now(),
 
 )

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/controller/EvaluationController.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/controller/EvaluationController.kt
@@ -3,6 +3,11 @@ package com.wafflestudio.snuttev.domain.evaluation.controller
 import com.wafflestudio.snuttev.domain.common.dto.CursorPaginationResponse
 import com.wafflestudio.snuttev.domain.evaluation.dto.*
 import com.wafflestudio.snuttev.domain.evaluation.service.EvaluationService
+import com.wafflestudio.snuttev.error.ErrorResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
 
@@ -11,6 +16,10 @@ class EvaluationController(
     private val evaluationService: EvaluationService,
 ) {
 
+    @Operation(responses = [
+        ApiResponse(responseCode = "200"),
+        ApiResponse(responseCode = "409", description = "29001 EVALUATION_ALREADY_EXISTS", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
+    ])
     @PostMapping("/v1/semester-lectures/{id}/evaluations")
     fun createEvaluation(
         @PathVariable(value = "id") semesterLectureId: Long,
@@ -27,6 +36,7 @@ class EvaluationController(
         return evaluationService.getEvaluationSummaryOfLecture(lectureId)
     }
 
+    @Operation(description = "해당 강의의 강의평 전체 수를 total_count, 자신의 강의평을 제외한 강의평들을 content로 제공")
     @GetMapping("/v1/lectures/{id}/evaluations")
     fun getLectureEvaluations(
         @PathVariable(value = "id") lectureId: Long,
@@ -61,6 +71,10 @@ class EvaluationController(
         return evaluationService.deleteLectureEvaluation(userId, evaluationId)
     }
 
+    @Operation(responses = [
+        ApiResponse(responseCode = "200"),
+        ApiResponse(responseCode = "409", description = "29003 EVALUATION_REPORT_ALREADY_EXISTS", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
+    ])
     @PostMapping("/v1/evaluations/{id}/report")
     fun reportLectureEvaluation(
         @PathVariable(value = "id") evaluationId: Long,

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/lecture/controller/LectureController.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/lecture/controller/LectureController.kt
@@ -6,6 +6,7 @@ import com.wafflestudio.snuttev.domain.common.dto.ListResponse
 import com.wafflestudio.snuttev.domain.common.dto.PaginationResponse
 import com.wafflestudio.snuttev.domain.lecture.dto.*
 import com.wafflestudio.snuttev.domain.lecture.service.LectureService
+import io.swagger.v3.oas.annotations.Parameter
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -36,7 +37,7 @@ class LectureController(
 
     @GetMapping("/v1/users/me/lectures/latest")
     fun getLecturesTakenByCurrentUser(
-        @RequestParam("snutt_lecture_info") snuttLectureInfoString: String? = "",
+        @Parameter(hidden = true) @RequestParam("snutt_lecture_info") snuttLectureInfoString: String? = "",
     ): ListResponse<LectureTakenByUserResponse> {
         val snuttLectureInfos: List<SnuttLectureInfo> =
             objectMapper.readValue(snuttLectureInfoString ?: "")


### PR DESCRIPTION
# Major Changes
## 1. Swagger description에서 user_id를 대체하는 schema 내용 수정

## 2. Swagger에서 GET /v1/users/me/lectures/latest 의 parameter 숨기기

## 3. Swagger API 설명에 클라이언트에서 반드시 대응해야 하는 ErrorResponse 경우를 추가

## 4. Swagger에서 혼란이 있을 만한 GET /v1/lectures/{id}/evaluations 에 description 추가
