### PR TITLE
Create health_check API

### DIFF
--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/common/controller/HealthCheckController.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/common/controller/HealthCheckController.kt
@@ -1,0 +1,15 @@
+package com.wafflestudio.snuttev.domain.common.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class HealthCheckController {
+
+    @Operation(hidden = true)
+    @GetMapping("/health_check")
+    fun healthCheck() {
+
+    }
+}

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/common/controller/HealthCheckController.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/common/controller/HealthCheckController.kt
@@ -10,6 +10,5 @@ class HealthCheckController {
     @Operation(hidden = true)
     @GetMapping("/health_check")
     fun healthCheck() {
-
     }
 }

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/controller/EvaluationController.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/controller/EvaluationController.kt
@@ -83,5 +83,4 @@ class EvaluationController(
     ): EvaluationReportDto {
         return evaluationService.reportLectureEvaluation(userId, evaluationId, createEvaluationReportRequest)
     }
-
 }


### PR DESCRIPTION
# Major Changes
## 1. ElasticBeanstalk load balancer 등에서 사용할 health check API 추가
- /v1/* 으로 시작되는 uri 가 아니기에 Snutt-User-Id 헤더도 필요 없음
