### PR TITLE
LectureClassification Enum 활용 및 GET /v1/tags/main/{id}/evaluations 에 '교양' 조건 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ ehthumbs_vista.db
 
 # Dump file
 *.stackdump
+dump.rdb
 
 # Folder config file
 [Dd]esktop.ini

--- a/src/main/kotlin/com/wafflestudio/snuttev/DataLoader.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/DataLoader.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snuttev
 
 import com.wafflestudio.snuttev.domain.common.Semester
 import com.wafflestudio.snuttev.domain.lecture.model.Lecture
+import com.wafflestudio.snuttev.domain.lecture.model.LectureClassification
 import com.wafflestudio.snuttev.domain.lecture.model.SemesterLecture
 import com.wafflestudio.snuttev.domain.lecture.repository.LectureRepository
 import com.wafflestudio.snuttev.domain.lecture.repository.SemesterLectureRepository
@@ -33,7 +34,7 @@ class DataLoader(
             credit = 4,
             academicYear = "3학년",
             category = "",
-            classification = "전선",
+            classification = LectureClassification.ELECTIVE_SUBJECT,
         )
         lectureRepository.save(lecture)
         val semesterLectures = listOf(
@@ -44,7 +45,7 @@ class DataLoader(
                 credit = 4,
                 academicYear = "3학년",
                 category = "",
-                classification = "전선",
+                classification = LectureClassification.ELECTIVE_SUBJECT,
             ),
             SemesterLecture(
                 lecture = lecture,
@@ -53,7 +54,7 @@ class DataLoader(
                 credit = 4,
                 academicYear = "3학년",
                 category = "",
-                classification = "전선",
+                classification = LectureClassification.ELECTIVE_SUBJECT,
             ),
             SemesterLecture(
                 lecture = lecture,
@@ -62,7 +63,7 @@ class DataLoader(
                 credit = 4,
                 academicYear = "3학년",
                 category = "",
-                classification = "전선",
+                classification = LectureClassification.ELECTIVE_SUBJECT,
             ),
             SemesterLecture(
                 lecture = lecture,
@@ -71,7 +72,7 @@ class DataLoader(
                 credit = 4,
                 academicYear = "3학년",
                 category = "",
-                classification = "전선",
+                classification = LectureClassification.ELECTIVE_SUBJECT,
             ),
         )
         semesterLectureRepository.saveAll(semesterLectures)
@@ -84,7 +85,7 @@ class DataLoader(
             credit = 3,
             academicYear = "1학년",
             category = "인간과 사회",
-            classification = "교양",
+            classification = LectureClassification.LIBERAL_EDUCATION,
         )
         lectureRepository.save(lecture2)
         val semesterLectures2 = listOf(
@@ -95,7 +96,7 @@ class DataLoader(
                 credit = 3,
                 academicYear = "1학년",
                 category = "인간과 사회",
-                classification = "교양",
+                classification = LectureClassification.LIBERAL_EDUCATION,
             ),
             SemesterLecture(
                 lecture = lecture,
@@ -104,7 +105,7 @@ class DataLoader(
                 credit = 3,
                 academicYear = "1학년",
                 category = "인간과 사회",
-                classification = "교양",
+                classification = LectureClassification.LIBERAL_EDUCATION,
             ),
         )
         semesterLectureRepository.saveAll(semesterLectures2)

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/dto/EvaluationResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/dto/EvaluationResponse.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snuttev.domain.evaluation.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.wafflestudio.snuttev.domain.lecture.model.LectureClassification
 
 
 data class LectureEvaluationDto(
@@ -54,7 +55,7 @@ data class SemesterLectureDto(
 
     val category: String,
 
-    val classification: String,
+    val classification: LectureClassification,
 )
 
 data class LectureEvaluationSummaryResponse(
@@ -76,7 +77,7 @@ data class LectureEvaluationSummaryResponse(
 
     val category: String?,
 
-    val classification: String?,
+    val classification: LectureClassification?,
 
     val evaluation: LectureEvaluationSummary,
 )

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/repository/LectureEvaluationRepository.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/repository/LectureEvaluationRepository.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snuttev.domain.evaluation.repository
 
 import com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluation
 import com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture
+import com.wafflestudio.snuttev.domain.lecture.model.LectureClassification
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -49,37 +50,41 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
         le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
-        from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false
+        from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
+        and sl.classification = :classification 
         order by le.id desc
     """
     )
-    fun findByLecturesRecentOrderByDesc(pageable: Pageable): List<LectureEvaluationWithLecture>
+    fun findByLecturesRecentOrderByDesc(classification: LectureClassification, pageable: Pageable): List<LectureEvaluationWithLecture>
 
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
         le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
-        from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false
+        from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
+        and sl.classification = :classification 
         and le.id < :cursorId 
         order by le.id desc
     """
     )
-    fun findByLecturesRecentLessThanOrderByDesc(cursorId: Long, pageable: Pageable): List<LectureEvaluationWithLecture>
+    fun findByLecturesRecentLessThanOrderByDesc(classification: LectureClassification, cursorId: Long, pageable: Pageable): List<LectureEvaluationWithLecture>
 
     @Query("""
         select 1 
         from lecture_evaluation le inner join semester_lecture sl on le.semester_lecture_id = sl.id where le.is_hidden = false 
+        and sl.classification = :#{#classification.value} 
         and le.id < :cursorId 
         limit 1
     """, nativeQuery = true
     )
-    fun existsByLecturesRecentLessThan(cursorId: Long): Int?
+    fun existsByLecturesRecentLessThan(classification: LectureClassification, cursorId: Long): Int?
 
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
         le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
+        and sl.classification = :classification 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
             group by sl1.lecture.id having avg(le1.rating) >= 4.0 
@@ -87,13 +92,14 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         order by le.id desc
     """
     )
-    fun findByLecturesRecommendedOrderByDesc(pageable: Pageable): List<LectureEvaluationWithLecture>
+    fun findByLecturesRecommendedOrderByDesc(classification: LectureClassification, pageable: Pageable): List<LectureEvaluationWithLecture>
 
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
         le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
+        and sl.classification = :classification 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
             group by sl1.lecture.id having avg(le1.rating) >= 4.0 
@@ -102,11 +108,12 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         order by le.id desc
     """
     )
-    fun findByLecturesRecommendedLessThanOrderByDesc(cursorId: Long, pageable: Pageable): List<LectureEvaluationWithLecture>
+    fun findByLecturesRecommendedLessThanOrderByDesc(classification: LectureClassification, cursorId: Long, pageable: Pageable): List<LectureEvaluationWithLecture>
 
     @Query("""
         select 1 
         from lecture_evaluation le inner join semester_lecture sl on le.semester_lecture_id = sl.id where le.is_hidden = false 
+        and sl.classification = :#{#classification.value} 
         and sl.lecture_id in ( 
             select sl1.lecture_id from lecture_evaluation le1 inner join semester_lecture sl1 on le1.semester_lecture_id = sl1.id and le1.is_hidden = false 
             group by sl1.lecture_id having avg(le1.rating) >= 4.0 
@@ -115,13 +122,14 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         limit 1
     """, nativeQuery = true
     )
-    fun existsByLecturesRecommendedLessThan(cursorId: Long): Int?
+    fun existsByLecturesRecommendedLessThan(classification: LectureClassification, cursorId: Long): Int?
 
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
         le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
+        and sl.classification = :classification 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
             group by sl1.lecture.id having avg(le1.teachingSkill) >= 4.0 and avg(le1.gains) >= 4.0 
@@ -129,13 +137,14 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         order by le.id desc
     """
     )
-    fun findByLecturesFineOrderByDesc(pageable: Pageable): List<LectureEvaluationWithLecture>
+    fun findByLecturesFineOrderByDesc(classification: LectureClassification, pageable: Pageable): List<LectureEvaluationWithLecture>
 
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
         le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
+        and sl.classification = :classification 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
             group by sl1.lecture.id having avg(le1.teachingSkill) >= 4.0 and avg(le1.gains) >= 4.0 
@@ -144,11 +153,12 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         order by le.id desc
     """
     )
-    fun findByLecturesFineLessThanOrderByDesc(cursorId: Long, pageable: Pageable): List<LectureEvaluationWithLecture>
+    fun findByLecturesFineLessThanOrderByDesc(classification: LectureClassification, cursorId: Long, pageable: Pageable): List<LectureEvaluationWithLecture>
 
     @Query("""
         select 1 
         from lecture_evaluation le inner join semester_lecture sl on le.semester_lecture_id = sl.id where le.is_hidden = false 
+        and sl.classification = :#{#classification.value} 
         and sl.lecture_id in ( 
             select sl1.lecture_id from lecture_evaluation le1 inner join semester_lecture sl1 on le1.semester_lecture_id = sl1.id and le1.is_hidden = false 
             group by sl1.lecture_id having avg(le1.teaching_skill) >= 4.0 and avg(le1.gains) >= 4.0 
@@ -157,13 +167,14 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         limit 1
     """, nativeQuery = true
     )
-    fun existsByLecturesFineLessThan(cursorId: Long): Int?
+    fun existsByLecturesFineLessThan(classification: LectureClassification, cursorId: Long): Int?
 
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
         le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
+        and sl.classification = :classification 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
             group by sl1.lecture.id having avg(le1.gradeSatisfaction) >= 4.0 and avg(le1.lifeBalance) >= 4.0 
@@ -171,13 +182,14 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         order by le.id desc
     """
     )
-    fun findByLecturesHoneyOrderByDesc(pageable: Pageable): List<LectureEvaluationWithLecture>
+    fun findByLecturesHoneyOrderByDesc(classification: LectureClassification, pageable: Pageable): List<LectureEvaluationWithLecture>
 
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
         le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
+        and sl.classification = :classification 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
             group by sl1.lecture.id having avg(le1.gradeSatisfaction) >= 4.0 and avg(le1.lifeBalance) >= 4.0 
@@ -186,11 +198,12 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         order by le.id desc
     """
     )
-    fun findByLecturesHoneyLessThanOrderByDesc(cursorId: Long, pageable: Pageable): List<LectureEvaluationWithLecture>
+    fun findByLecturesHoneyLessThanOrderByDesc(classification: LectureClassification, cursorId: Long, pageable: Pageable): List<LectureEvaluationWithLecture>
 
     @Query("""
         select 1 
         from lecture_evaluation le inner join semester_lecture sl on le.semester_lecture_id = sl.id where le.is_hidden = false 
+        and sl.classification = :#{#classification.value} 
         and sl.lecture_id in ( 
             select sl1.lecture_id from lecture_evaluation le1 inner join semester_lecture sl1 on le1.semester_lecture_id = sl1.id and le1.is_hidden = false 
             group by sl1.lecture_id having avg(le1.grade_satisfaction) >= 4.0 and avg(le1.life_balance) >= 4.0 
@@ -199,13 +212,14 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         limit 1
     """, nativeQuery = true
     )
-    fun existsByLecturesHoneyLessThan(cursorId: Long): Int?
+    fun existsByLecturesHoneyLessThan(classification: LectureClassification, cursorId: Long): Int?
 
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
         le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
+        and sl.classification = :classification 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
             group by sl1.lecture.id having avg(le1.lifeBalance) < 2.0 and avg(le1.gains) >= 4.0 
@@ -213,13 +227,14 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         order by le.id desc
     """
     )
-    fun findByLecturesPainsGainsOrderByDesc(pageable: Pageable): List<LectureEvaluationWithLecture>
+    fun findByLecturesPainsGainsOrderByDesc(classification: LectureClassification, pageable: Pageable): List<LectureEvaluationWithLecture>
 
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(
         le.id, le.userId, le.content, le.gradeSatisfaction, le.teachingSkill, le.gains, le.lifeBalance, le.rating, 
         le.likeCount, le.dislikeCount, le.isHidden, le.isReported, sl.year, sl.semester, sl.lecture.id, sl.lecture.title, sl.lecture.instructor) 
         from LectureEvaluation le inner join le.semesterLecture sl where le.isHidden = false 
+        and sl.classification = :classification 
         and sl.lecture.id in ( 
             select sl1.lecture.id from LectureEvaluation le1 inner join SemesterLecture sl1 on le1.semesterLecture.id = sl1.id and le1.isHidden = false 
             group by sl1.lecture.id having avg(le1.lifeBalance) < 2.0 and avg(le1.gains) >= 4.0 
@@ -228,11 +243,12 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         order by le.id desc
     """
     )
-    fun findByLecturesPainsGainsLessThanOrderByDesc(cursorId: Long, pageable: Pageable): List<LectureEvaluationWithLecture>
+    fun findByLecturesPainsGainsLessThanOrderByDesc(classification: LectureClassification, cursorId: Long, pageable: Pageable): List<LectureEvaluationWithLecture>
 
     @Query("""
         select 1 
         from lecture_evaluation le inner join semester_lecture sl on le.semester_lecture_id = sl.id where le.is_hidden = false 
+        and sl.classification = :#{#classification.value} 
         and sl.lecture_id in ( 
             select sl1.lecture_id from lecture_evaluation le1 inner join semester_lecture sl1 on le1.semester_lecture_id = sl1.id and le1.is_hidden = false 
             group by sl1.lecture_id having avg(le1.life_balance) < 2.0 and avg(le1.gains) >= 4.0 
@@ -241,7 +257,7 @@ interface LectureEvaluationRepository : JpaRepository<LectureEvaluation, Long> {
         limit 1
     """, nativeQuery = true
     )
-    fun existsByLecturesPainsGainsLessThan(cursorId: Long): Int?
+    fun existsByLecturesPainsGainsLessThan(classification: LectureClassification, cursorId: Long): Int?
 
     @Query("""
         select new com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture(

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/service/EvaluationService.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/evaluation/service/EvaluationService.kt
@@ -8,6 +8,7 @@ import com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluation
 import com.wafflestudio.snuttev.domain.evaluation.model.LectureEvaluationWithLecture
 import com.wafflestudio.snuttev.domain.evaluation.repository.EvaluationReportRepository
 import com.wafflestudio.snuttev.domain.evaluation.repository.LectureEvaluationRepository
+import com.wafflestudio.snuttev.domain.lecture.model.LectureClassification
 import com.wafflestudio.snuttev.domain.lecture.repository.LectureRepository
 import com.wafflestudio.snuttev.domain.lecture.repository.SemesterLectureRepository
 import com.wafflestudio.snuttev.domain.tag.repository.TagRepository
@@ -176,12 +177,14 @@ class EvaluationService(
             throw WrongCursorFormatException
         }
 
+        val classification = LectureClassification.LIBERAL_EDUCATION
+
         val cursorPaginationForLectureEvaluationWithLectureDto = when (tag.name) {
-            "최신" -> self.getLectureEvaluationsWithLectureFromTagRecent(cursorId, pageable)
-            "추천" -> self.getLectureEvaluationsWithLectureFromTagRecommended(cursorId, pageable)
-            "명강" -> self.getLectureEvaluationsWithLectureFromTagFine(cursorId, pageable)
-            "꿀강" -> self.getLectureEvaluationsWithLectureFromTagHoney(cursorId, pageable)
-            "고진감래" -> self.getLectureEvaluationsWithLectureFromTagPainsGains(cursorId, pageable)
+            "최신" -> self.getLectureEvaluationsWithLectureFromTagRecent(classification, cursorId, pageable)
+            "추천" -> self.getLectureEvaluationsWithLectureFromTagRecommended(classification, cursorId, pageable)
+            "명강" -> self.getLectureEvaluationsWithLectureFromTagFine(classification, cursorId, pageable)
+            "꿀강" -> self.getLectureEvaluationsWithLectureFromTagHoney(classification, cursorId, pageable)
+            "고진감래" -> self.getLectureEvaluationsWithLectureFromTagPainsGains(classification, cursorId, pageable)
             else -> throw WrongMainTagException
         }
 
@@ -233,17 +236,17 @@ class EvaluationService(
     }
 
     @Cacheable("tag-recent-evaluations")
-    fun getLectureEvaluationsWithLectureFromTagRecent(cursorId: Long?, pageable: Pageable): CursorPaginationForLectureEvaluationWithLectureDto {
+    fun getLectureEvaluationsWithLectureFromTagRecent(classification: LectureClassification, cursorId: Long?, pageable: Pageable): CursorPaginationForLectureEvaluationWithLectureDto {
         val lectureEvaluationsWithLecture = cursorId?.let {
-            lectureEvaluationRepository.findByLecturesRecentLessThanOrderByDesc(cursorId, pageable)
-        } ?: lectureEvaluationRepository.findByLecturesRecentOrderByDesc(pageable)
+            lectureEvaluationRepository.findByLecturesRecentLessThanOrderByDesc(classification, cursorId, pageable)
+        } ?: lectureEvaluationRepository.findByLecturesRecentOrderByDesc(classification, pageable)
 
         val lastLectureEvaluationWithLecture = lectureEvaluationsWithLecture.lastOrNull()
 
         val nextCursor = lastLectureEvaluationWithLecture?.id?.toString()
 
         val isLast = lastLectureEvaluationWithLecture?.let {
-            lectureEvaluationRepository.existsByLecturesRecentLessThan(it.id!!) == null
+            lectureEvaluationRepository.existsByLecturesRecentLessThan(classification, it.id!!) == null
         } ?: true
 
         return CursorPaginationForLectureEvaluationWithLectureDto(
@@ -254,17 +257,17 @@ class EvaluationService(
     }
 
     @Cacheable("tag-recommended-evaluations")
-    fun getLectureEvaluationsWithLectureFromTagRecommended(cursorId: Long?, pageable: Pageable): CursorPaginationForLectureEvaluationWithLectureDto {
+    fun getLectureEvaluationsWithLectureFromTagRecommended(classification: LectureClassification, cursorId: Long?, pageable: Pageable): CursorPaginationForLectureEvaluationWithLectureDto {
         val lectureEvaluationsWithLecture = cursorId?.let {
-            lectureEvaluationRepository.findByLecturesRecommendedLessThanOrderByDesc(cursorId, pageable)
-        } ?: lectureEvaluationRepository.findByLecturesRecommendedOrderByDesc(pageable)
+            lectureEvaluationRepository.findByLecturesRecommendedLessThanOrderByDesc(classification, cursorId, pageable)
+        } ?: lectureEvaluationRepository.findByLecturesRecommendedOrderByDesc(classification, pageable)
 
         val lastLectureEvaluationWithLecture = lectureEvaluationsWithLecture.lastOrNull()
 
         val nextCursor = lastLectureEvaluationWithLecture?.id?.toString()
 
         val isLast = lastLectureEvaluationWithLecture?.let {
-            lectureEvaluationRepository.existsByLecturesRecommendedLessThan(it.id!!) == null
+            lectureEvaluationRepository.existsByLecturesRecommendedLessThan(classification, it.id!!) == null
         } ?: true
 
         return CursorPaginationForLectureEvaluationWithLectureDto(
@@ -275,17 +278,17 @@ class EvaluationService(
     }
 
     @Cacheable("tag-fine-evaluations")
-    fun getLectureEvaluationsWithLectureFromTagFine(cursorId: Long?, pageable: Pageable): CursorPaginationForLectureEvaluationWithLectureDto {
+    fun getLectureEvaluationsWithLectureFromTagFine(classification: LectureClassification, cursorId: Long?, pageable: Pageable): CursorPaginationForLectureEvaluationWithLectureDto {
         val lectureEvaluationsWithLecture = cursorId?.let {
-            lectureEvaluationRepository.findByLecturesFineLessThanOrderByDesc(cursorId, pageable)
-        } ?: lectureEvaluationRepository.findByLecturesFineOrderByDesc(pageable)
+            lectureEvaluationRepository.findByLecturesFineLessThanOrderByDesc(classification, cursorId, pageable)
+        } ?: lectureEvaluationRepository.findByLecturesFineOrderByDesc(classification, pageable)
 
         val lastLectureEvaluationWithLecture = lectureEvaluationsWithLecture.lastOrNull()
 
         val nextCursor = lastLectureEvaluationWithLecture?.id?.toString()
 
         val isLast = lastLectureEvaluationWithLecture?.let {
-            lectureEvaluationRepository.existsByLecturesFineLessThan(it.id!!) == null
+            lectureEvaluationRepository.existsByLecturesFineLessThan(classification, it.id!!) == null
         } ?: true
 
         return CursorPaginationForLectureEvaluationWithLectureDto(
@@ -296,17 +299,17 @@ class EvaluationService(
     }
 
     @Cacheable("tag-honey-evaluations")
-    fun getLectureEvaluationsWithLectureFromTagHoney(cursorId: Long?, pageable: Pageable): CursorPaginationForLectureEvaluationWithLectureDto {
+    fun getLectureEvaluationsWithLectureFromTagHoney(classification: LectureClassification, cursorId: Long?, pageable: Pageable): CursorPaginationForLectureEvaluationWithLectureDto {
         val lectureEvaluationsWithLecture = cursorId?.let {
-            lectureEvaluationRepository.findByLecturesHoneyLessThanOrderByDesc(cursorId, pageable)
-        } ?: lectureEvaluationRepository.findByLecturesHoneyOrderByDesc(pageable)
+            lectureEvaluationRepository.findByLecturesHoneyLessThanOrderByDesc(classification, cursorId, pageable)
+        } ?: lectureEvaluationRepository.findByLecturesHoneyOrderByDesc(classification, pageable)
 
         val lastLectureEvaluationWithLecture = lectureEvaluationsWithLecture.lastOrNull()
 
         val nextCursor = lastLectureEvaluationWithLecture?.id?.toString()
 
         val isLast = lastLectureEvaluationWithLecture?.let {
-            lectureEvaluationRepository.existsByLecturesHoneyLessThan(it.id!!) == null
+            lectureEvaluationRepository.existsByLecturesHoneyLessThan(classification, it.id!!) == null
         } ?: true
 
         return CursorPaginationForLectureEvaluationWithLectureDto(
@@ -317,17 +320,17 @@ class EvaluationService(
     }
 
     @Cacheable("tag-painsgains-evaluations")
-    fun getLectureEvaluationsWithLectureFromTagPainsGains(cursorId: Long?, pageable: Pageable): CursorPaginationForLectureEvaluationWithLectureDto {
+    fun getLectureEvaluationsWithLectureFromTagPainsGains(classification: LectureClassification, cursorId: Long?, pageable: Pageable): CursorPaginationForLectureEvaluationWithLectureDto {
         val lectureEvaluationsWithLecture = cursorId?.let {
-            lectureEvaluationRepository.findByLecturesPainsGainsLessThanOrderByDesc(cursorId, pageable)
-        } ?: lectureEvaluationRepository.findByLecturesPainsGainsOrderByDesc(pageable)
+            lectureEvaluationRepository.findByLecturesPainsGainsLessThanOrderByDesc(classification, cursorId, pageable)
+        } ?: lectureEvaluationRepository.findByLecturesPainsGainsOrderByDesc(classification, pageable)
 
         val lastLectureEvaluationWithLecture = lectureEvaluationsWithLecture.lastOrNull()
 
         val nextCursor = lastLectureEvaluationWithLecture?.id?.toString()
 
         val isLast = lastLectureEvaluationWithLecture?.let {
-            lectureEvaluationRepository.existsByLecturesPainsGainsLessThan(it.id!!) == null
+            lectureEvaluationRepository.existsByLecturesPainsGainsLessThan(classification, it.id!!) == null
         } ?: true
 
         return CursorPaginationForLectureEvaluationWithLectureDto(

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/lecture/dto/LectureResponse.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/lecture/dto/LectureResponse.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snuttev.domain.lecture.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.wafflestudio.snuttev.domain.evaluation.dto.SemesterLectureDto
+import com.wafflestudio.snuttev.domain.lecture.model.LectureClassification
 
 data class LectureDto(
     val id: Long,
@@ -22,7 +23,7 @@ data class LectureDto(
 
     val category: String?,
 
-    val classification: String?,
+    val classification: LectureClassification?,
 
     val evaluation: LectureEvaluationSimpleSummary
 )
@@ -51,7 +52,7 @@ data class LectureAndSemesterLecturesResponse(
 
     val category: String?,
 
-    val classification: String?,
+    val classification: LectureClassification?,
 
     @JsonProperty("semester_lectures")
     val semesterLectures: List<SemesterLectureDto>
@@ -80,7 +81,7 @@ data class LectureTakenByUserResponse(
 
     val category: String?,
 
-    val classification: String?,
+    val classification: LectureClassification?,
 
     @JsonProperty("taken_year")
     val takenYear: Int,

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/lecture/model/Lecture.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/lecture/model/Lecture.kt
@@ -2,7 +2,6 @@ package com.wafflestudio.snuttev.domain.lecture.model
 
 import com.fasterxml.jackson.annotation.JsonValue
 import com.wafflestudio.snuttev.domain.common.model.BaseEntity
-import java.util.*
 import javax.persistence.*
 import javax.validation.constraints.NotBlank
 

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/lecture/model/Lecture.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/lecture/model/Lecture.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snuttev.domain.lecture.model
 
 import com.fasterxml.jackson.annotation.JsonValue
 import com.wafflestudio.snuttev.domain.common.model.BaseEntity
+import java.util.*
 import javax.persistence.*
 import javax.validation.constraints.NotBlank
 
@@ -26,7 +27,8 @@ class Lecture(
 
     var category: String,
 
-    var classification: String,
+    @Convert(converter = LectureClassificationConverter::class)
+    var classification: LectureClassification,
 
     @OneToMany(mappedBy = "lecture")
     val semesterLectures: List<SemesterLecture> = listOf()
@@ -41,9 +43,21 @@ enum class LectureClassification(@get:JsonValue val value: String) {
     READING_AND_RESEARCH("논문"),
     TEACHING_CERTIFICATION("교직"),
     GRADUATE("대학원"),
-    CORE_SUBJECT("공통"),
+    CORE_SUBJECT("공통");
+
+    companion object {
+        private val mapping = values().associateBy { e -> e.value }
+
+        fun customValueOf(classification: String): LectureClassification? = mapping.getOrDefault(classification, null)
+    }
 }
 
+class LectureClassificationConverter: AttributeConverter<LectureClassification, String> {
+    override fun convertToDatabaseColumn(attribute: LectureClassification?): String? = attribute?.value
+
+    override fun convertToEntityAttribute(dbData: String?): LectureClassification? =
+        dbData?.let { LectureClassification.customValueOf(it) }
+}
 
 data class LectureEvaluationSummaryDao(
     val id: Long?,
@@ -62,7 +76,7 @@ data class LectureEvaluationSummaryDao(
 
     val category: String?,
 
-    val classification: String?,
+    val classification: LectureClassification?,
 
     val avgGradeSatisfaction: Double?,
 

--- a/src/main/kotlin/com/wafflestudio/snuttev/domain/lecture/model/SemesterLecture.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/domain/lecture/model/SemesterLecture.kt
@@ -26,7 +26,8 @@ class SemesterLecture(
 
     var category: String,
 
-    var classification: String,
+    @Convert(converter = LectureClassificationConverter::class)
+    var classification: LectureClassification,
 
     @OneToMany(mappedBy = "semesterLecture")
     val evaluations: List<LectureEvaluation> = listOf()
@@ -47,7 +48,7 @@ data class SemesterLectureWithLecture(
 
     var category: String,
 
-    var classification: String,
+    var classification: LectureClassification,
 
     val lectureId: Long,
 

--- a/src/main/kotlin/com/wafflestudio/snuttev/scheduler/lecture_crawler/SnuttLectureSyncJobScheduler.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/scheduler/lecture_crawler/SnuttLectureSyncJobScheduler.kt
@@ -10,7 +10,7 @@ import javax.annotation.PostConstruct
 class SnuttLectureSyncJobScheduler(private val service: SnuttLectureSyncJobService) {
 
     //    전체 수강편람 옮기는 job, local인 경우에만 작동
-    @PostConstruct
+//    @PostConstruct
     fun fetchAll() {
         service.migrateAllLectureDataFromSnutt()
     }

--- a/src/main/kotlin/com/wafflestudio/snuttev/scheduler/lecture_crawler/SnuttLectureSyncJobScheduler.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/scheduler/lecture_crawler/SnuttLectureSyncJobScheduler.kt
@@ -10,7 +10,7 @@ import javax.annotation.PostConstruct
 class SnuttLectureSyncJobScheduler(private val service: SnuttLectureSyncJobService) {
 
     //    전체 수강편람 옮기는 job, local인 경우에만 작동
-//    @PostConstruct
+    @PostConstruct
     fun fetchAll() {
         service.migrateAllLectureDataFromSnutt()
     }

--- a/src/main/kotlin/com/wafflestudio/snuttev/scheduler/lecture_crawler/SnuttLectureSyncJobService.kt
+++ b/src/main/kotlin/com/wafflestudio/snuttev/scheduler/lecture_crawler/SnuttLectureSyncJobService.kt
@@ -1,6 +1,7 @@
 package com.wafflestudio.snuttev.scheduler.lecture_crawler
 
 import com.wafflestudio.snuttev.domain.lecture.model.Lecture
+import com.wafflestudio.snuttev.domain.lecture.model.LectureClassification
 import com.wafflestudio.snuttev.domain.lecture.model.SemesterLecture
 import com.wafflestudio.snuttev.domain.lecture.repository.SemesterLectureRepository
 import com.wafflestudio.snuttev.domain.lecture.repository.LectureRepository
@@ -70,7 +71,7 @@ class SnuttLectureSyncJobService(
             semesterLectureKeyOf(it) to (existingSemesterLecturesMap[semesterLectureKeyOf(it)]?.apply {
                 this.academicYear = it.academic_year
                 this.category = it.category
-                this.classification = it.classification
+                this.classification = LectureClassification.customValueOf(it.classification)!!
                 this.extraInfo = it.remark
                 this.lecture = lecture
                 this.credit = it.credit
@@ -87,7 +88,7 @@ class SnuttLectureSyncJobService(
             lectureKeyOf(it) to (originalLecturesMap[lectureKeyOf(it)]?.apply {
                 this.academicYear = it.academic_year
                 this.credit = it.credit
-                this.classification = it.classification
+                this.classification = LectureClassification.customValueOf(it.classification)!!
                 this.category = it.category
             } ?: createNewLectureFromSnuttSemesterLecture(it))
         }
@@ -102,7 +103,7 @@ class SnuttLectureSyncJobService(
             e.credit,
             e.academic_year,
             e.category,
-            e.classification
+            LectureClassification.customValueOf(e.classification)!!,
         )
     }
 
@@ -110,7 +111,14 @@ class SnuttLectureSyncJobService(
         e: SnuttSemesterLecture, lecture: Lecture
     ): SemesterLecture {
         return SemesterLecture(
-            lecture, e.year, e.semester, e.credit, e.remark, e.academic_year, e.category, e.classification
+            lecture,
+            e.year,
+            e.semester,
+            e.credit,
+            e.remark,
+            e.academic_year,
+            e.category,
+            LectureClassification.customValueOf(e.classification)!!,
         )
     }
 

--- a/src/test/kotlin/com/wafflestudio/snuttev/scheduler/SnuttLectureSyncJobSliceTest.kt
+++ b/src/test/kotlin/com/wafflestudio/snuttev/scheduler/SnuttLectureSyncJobSliceTest.kt
@@ -40,7 +40,7 @@ class SnuttLectureSyncJobSliceTest(
     ): SnuttSemesterLecture {
         return SnuttSemesterLecture(
             id = "",
-            classification = "",
+            classification = "교양",
             department = "",
             academic_year = "",
             courseTitle = "",


### PR DESCRIPTION
related issues: https://draft-waffle.atlassian.net/browse/SNUTT-246

# Major Changes
## 1. Lecture 및 SemesterLecture 에서 classification 을 위해 String 대신 enum LectureClassification 활용
- 관련 코드 수정
- GET /v1/lectures 에서 QueryDSL 사용된 부분에서 EnumPath 관련 함수 추가 cc. @Hank-Choi 

## 2. GET /v1/tags/main/{id}/evaluations
- 기획 스펙과 달리 '교양'에 한정하지 않던 API 수정
  