### PR TITLE
local tomcat accesslog true

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -14,6 +14,16 @@ spring:
   jpa:
     show-sql: true
 
+server:
+  tomcat:
+    accesslog:
+      enabled: true
+      directory: /dev
+      prefix: stdout
+      buffered: false
+      suffix:
+      file-date-format:
+
 ---
 
 spring.config.activate.on-profile: dev
@@ -27,6 +37,11 @@ spring:
   jpa:
     show-sql: false
 
+server:
+  tomcat:
+    accesslog:
+      enabled: false
+
 ---
 
 spring.config.activate.on-profile: prod
@@ -39,3 +54,8 @@ spring:
     ttl: 10m
   jpa:
     show-sql: false
+
+server:
+  tomcat:
+    accesslog:
+      enabled: false


### PR DESCRIPTION
local profile 인 경우, access log 가 찍히면 디버깅에 편리한 경우가 있을 거 같아서 enable 합니다.

dev, prod 환경의 경우는 k8s 의 경우 앞단의 istio-proxy 가, EB 인 경우 앞단의 nginx 가 찍어줄테니 X. 로컬에서 해당 profile 로 띄우면서 access log 찍고 싶으면 enabled: true 로만 바꿔주면 됩니다.
