### PR TITLE
Use readonly transactional for tags APIs

### DIFF
--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/tag/service/TagService.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/tag/service/TagService.kt
@@ -8,16 +8,19 @@ import com.wafflestudio.snuttev.core.domain.tag.model.Tag
 import com.wafflestudio.snuttev.core.domain.tag.model.TagGroup
 import com.wafflestudio.snuttev.core.domain.tag.repository.TagGroupRepository
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class TagService(
     private val tagGroupRepository: TagGroupRepository,
 ) {
+    @Transactional(readOnly = true)
     fun getMainTags(): TagGroupDto {
         val tagGroup = tagGroupRepository.findByName(name = "main") ?: throw TagGroupNotFoundException
         return genTagGroupDto(tagGroup)
     }
 
+    @Transactional(readOnly = true)
     fun getSearchTags(): SearchTagResponse {
         val tagGroups = tagGroupRepository.findAllByNameNotOrderByOrdering(name = "main")
         return SearchTagResponse(


### PR DESCRIPTION
`open-in-view: false` 로 적용해서 dev 배포해서 이슈 발견
https://wafflestudio.slack.com/archives/C0PAVPS5T/p1668572471830589?thread_ts=1668569314.520049&cid=C0PAVPS5T

tagGroup 의 tags 들을 lazy 하게 가져올 때, Transaction 이미 끝나 있어서 no session 오류.

해결하는 몇 가지 방법이 있을 거 같은데 일단 회사라 재빠르게 이거 달고 해결합니다.
더 좋은 의견은 따로 주세요.

명시적으로 fetch join 해서 한 번에 tags, taggroup 가져오게 하는 게 나을까요? @Hank-Choi 
