### PR TITLE
Fix typo in "꿀강" Query

### DIFF
--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/evaluation/repository/LectureEvaluationRepositoryImpl.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/evaluation/repository/LectureEvaluationRepositoryImpl.kt
@@ -82,7 +82,7 @@ class LectureEvaluationRepositoryImpl(private val queryFactory: JPAQueryFactory)
                 "명강" -> lectureEvaluation.teachingSkill.avg().goe(4.0)
                     .and(lectureEvaluation.gains.avg().goe(4.0))
                 "꿀강" -> lectureEvaluation.gradeSatisfaction.avg().goe(4.0)
-                    .and(lectureEvaluation.lifeBalance.goe(4.0))
+                    .and(lectureEvaluation.lifeBalance.avg().goe(4.0))
                 "고진감래" -> lectureEvaluation.lifeBalance.avg().lt(2.0)
                     .and(lectureEvaluation.gains.avg().goe(4.0))
                 else -> throw WrongMainTagException

--- a/core/src/main/resources/application-core.yml
+++ b/core/src/main/resources/application-core.yml
@@ -43,9 +43,6 @@ spring:
   jpa:
     show-sql: false
   redis:
-    host:
-    port:
-    database:
     ttl: 5m
 
 ---
@@ -62,7 +59,4 @@ spring:
   jpa:
     show-sql: false
   redis:
-    host:
-    port:
-    database:
     ttl: 1h


### PR DESCRIPTION
<img width="1063" alt="스크린샷 2022-11-20 13 15 14" src="https://user-images.githubusercontent.com/35535636/202885141-7c661b53-7bac-4aba-b81e-9960d849df82.png">

이슈 수정

+ SecretsManager 에서 가져오는 redis 빈 '' 굳이 명시할 필요 없어서 제거