### PR TITLE
header size 증가

### DIFF
--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -18,6 +18,7 @@ server:
       buffered: false
       suffix:
       file-date-format:
+  max-http-request-header-size: 100KB
 
 ---
 


### PR DESCRIPTION
```
2023-10-17T05:34:04.591Z  INFO 8 --- [nio-8080-exec-4] o.apache.coyote.http11.Http11Processor   : Error parsing HTTP request header Note: further occurrences of HTTP request parsing errors will be logged at DEBUG 

level.java.lang.IllegalArgumentException: Request header is too large	at org.apache.coyote.http11.Http11InputBuffer.fill(Http11InputBuffer.java:770) ~[tomcat-embed-core-10.1.8.jar!/:na]	at org.apache.coyote.http11.Http11InputBuffer.parseRequestLine(Http11InputBuffer.java:442) ~[tomcat-embed-core-10.1.8.jar!/:na]	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:263) ~[tomcat-embed-core-10.1.8.jar!/:na]	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63) ~[tomcat-embed-core-10.1.8.jar!/:na]	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:894) ~[tomcat-embed-core-10.1.8.jar!/:na]	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1741) ~[tomcat-embed-core-10.1.8.jar!/:na]	at org.apache.tomcat.util.net.SocketProcessorBase.run(SocketProcessorBase.java:52) ~[tomcat-embed-core-10.1.8.jar!/:na]	at org.apache.tomcat.util.threads.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1191) ~[tomcat-embed-core-10.1.8.jar!/:na]	at org.apache.tomcat.util.threads.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:659) ~[tomcat-embed-core-10.1.8.jar!/:na]	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61) ~[tomcat-embed-core-10.1.8.jar!/:na]	at java.base/java.lang.Thread.run(Thread.java:833) ~[na:na]
```