### PR TITLE
snutt 전달용 강의평점 api 생성

### DIFF
--- a/api/src/main/kotlin/com/wafflestudio/snuttev/controller/LectureController.kt
+++ b/api/src/main/kotlin/com/wafflestudio/snuttev/controller/LectureController.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.snuttev.core.common.dto.common.PaginationResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureAndSemesterLecturesResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureDto
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureIdResponse
+import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureRatingResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureTakenByUserResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SearchLectureRequest
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SnuttLectureInfo
@@ -44,6 +45,22 @@ class LectureController(
         @RequestParam("instructor") instructor: String,
     ): LectureIdResponse {
         return lectureService.getLectureIdFromCourseNumber(courseNumber, instructor)
+    }
+
+    @GetMapping("/v1/lecturesBySnutt/{semesterLectureSnuttId}/id")
+    fun getLectureId(
+        @PathVariable(value = "semesterLectureSnuttId") semesterLectureCoreId: String,
+    ): LectureIdResponse {
+        val lectureId = lectureService.getLectureIdFromSnuttId(semesterLectureCoreId)
+        return LectureIdResponse(lectureId)
+    }
+
+    @GetMapping("/v1/lecturesBySnutt/ratings")
+    fun getLectureRatings(
+        @RequestParam("semesterLectureSnuttIds") semesterLectureCoreIds: List<String>,
+    ): ListResponse<LectureRatingResponse> {
+        val lectureRatings = lectureService.getLectureRatings(semesterLectureCoreIds)
+        return ListResponse(lectureRatings)
     }
 
     @GetMapping("/v1/users/me/lectures/latest")

--- a/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
+++ b/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
@@ -1,13 +1,11 @@
 package com.wafflestudio.snuttev.sync
 
 import com.wafflestudio.snuttev.core.common.type.LectureClassification
-import com.wafflestudio.snuttev.core.common.util.SemesterUtils
 import com.wafflestudio.snuttev.core.domain.lecture.model.Lecture
 import com.wafflestudio.snuttev.core.domain.lecture.model.SemesterLecture
 import com.wafflestudio.snuttev.core.domain.lecture.repository.LectureRepository
 import com.wafflestudio.snuttev.core.domain.lecture.repository.SemesterLectureRepository
 import com.wafflestudio.snuttev.sync.model.SnuttSemesterLecture
-import com.wafflestudio.snuttev.sync.repository.SnuttSemesterLectureRepository
 import jakarta.persistence.EntityManagerFactory
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.Step
@@ -136,6 +134,7 @@ class SnuttLectureSyncJobConfig(
                 this.extraInfo = item.remark
                 this.lecture = lecture
                 this.credit = item.credit
+                this.snuttId = item.id
             } ?: SemesterLecture(
                 lecture,
                 item.year,
@@ -145,6 +144,7 @@ class SnuttLectureSyncJobConfig(
                 item.academicYear,
                 item.category,
                 LectureClassification.customValueOf(item.classification)!!,
+                item.id,
             ).also { semesterLecturesMap["${item.courseNumber},${item.instructor},${item.year},${item.semester}"] = it }
         }
     }

--- a/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
+++ b/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
@@ -16,8 +16,8 @@ import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.core.step.builder.StepBuilder
 import org.springframework.batch.item.ItemProcessor
 import org.springframework.batch.item.ItemWriter
-import org.springframework.batch.item.data.MongoItemReader
-import org.springframework.batch.item.data.builder.MongoItemReaderBuilder
+import org.springframework.batch.item.data.MongoCursorItemReader
+import org.springframework.batch.item.data.builder.MongoCursorItemReaderBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -36,8 +36,6 @@ class SnuttLectureSyncJobConfig(
     private val mongoTemplate: MongoTemplate,
     private val semesterLectureRepository: SemesterLectureRepository,
     private val lectureRepository: LectureRepository,
-    private val semesterUtils: SemesterUtils,
-    private val snuttSemesterLectureRepository: SnuttSemesterLectureRepository,
 ) {
     companion object {
         private const val JOB_NAME = "SYNC_JOB"
@@ -104,12 +102,12 @@ class SnuttLectureSyncJobConfig(
             .build()
     }
 
-    private fun reader(query: Query): MongoItemReader<SnuttSemesterLecture> {
-        return MongoItemReaderBuilder<SnuttSemesterLecture>()
+    private fun reader(query: Query): MongoCursorItemReader<SnuttSemesterLecture> {
+        return MongoCursorItemReaderBuilder<SnuttSemesterLecture>()
             .template(mongoTemplate)
             .collection("lectures").query(query)
-            .sorts(mapOf("courseNumber" to Sort.DEFAULT_DIRECTION))
-            .targetType(SnuttSemesterLecture::class.java).pageSize(CHUNK_SIZE)
+            .sorts(mapOf("_id" to Sort.DEFAULT_DIRECTION))
+            .targetType(SnuttSemesterLecture::class.java)
             .name(this::reader.name)
             .build()
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 import java.io.ByteArrayOutputStream
 
 plugins {
-    id("org.springframework.boot") version "3.1.4" apply false
+    id("org.springframework.boot") version "3.2.4" apply false
     id("io.spring.dependency-management") version "1.1.3"
     kotlin("jvm") version "1.9.10"
     kotlin("plugin.spring") version "1.8.21"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,10 +6,10 @@ import java.io.ByteArrayOutputStream
 plugins {
     id("org.springframework.boot") version "3.2.4" apply false
     id("io.spring.dependency-management") version "1.1.3"
-    kotlin("jvm") version "1.9.10"
-    kotlin("plugin.spring") version "1.8.21"
-    kotlin("plugin.allopen") version "1.8.21"
-    kotlin("plugin.noarg") version "1.8.21"
+    kotlin("jvm") version "1.9.22"
+    kotlin("plugin.spring") version "1.9.22"
+    kotlin("plugin.allopen") version "1.9.22"
+    kotlin("plugin.noarg") version "1.9.22"
     id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
 }
 

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/dto/LectureResponse.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/dto/LectureResponse.kt
@@ -50,3 +50,8 @@ data class LectureTakenByUserResponse(
     val takenYear: Int,
     val takenSemester: Int,
 )
+
+data class LectureRatingResponse(
+    val snuttId: String,
+    val avgRating: Double?
+)

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/model/SemesterLecture.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/model/SemesterLecture.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
@@ -14,7 +15,10 @@ import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 
 @Entity
-@Table(uniqueConstraints = [UniqueConstraint(columnNames = ["lecture_id", "year", "semester"])])
+@Table(
+    uniqueConstraints = [UniqueConstraint(columnNames = ["lecture_id", "year", "semester"])],
+    indexes = [Index(name = "semester_lecture_snutt_id_index", columnList = "snutt_id")],
+)
 class SemesterLecture(
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "lecture_id", nullable = false)
@@ -36,6 +40,9 @@ class SemesterLecture(
 
     @Convert(converter = LectureClassificationConverter::class)
     var classification: LectureClassification,
+
+    @Column(name = "snutt_id", columnDefinition = "char(24)")
+    var snuttId: String? = null,
 
     @OneToMany(mappedBy = "semesterLecture")
     val evaluations: List<LectureEvaluation> = listOf(),

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/LectureRepository.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/LectureRepository.kt
@@ -22,4 +22,7 @@ interface LectureRepository : JpaRepository<Lecture, Long?>, LectureRepositoryCu
     """,
     )
     fun findLectureWithAvgEvById(id: Long): LectureEvaluationSummaryDao
+
+    @Query("SELECT l FROM Lecture AS l JOIN SemesterLecture sl WHERE sl.snuttId = :snuttId")
+    fun findBySnuttId(snuttId: String): Lecture?
 }

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/LectureRepositoryCustom.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/LectureRepositoryCustom.kt
@@ -2,10 +2,12 @@ package com.wafflestudio.snuttev.core.domain.lecture.repository
 
 import com.wafflestudio.snuttev.core.common.dto.SearchQueryDto
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureDto
+import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureRatingResponse
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface LectureRepositoryCustom {
     fun searchLectures(request: SearchQueryDto, pageable: Pageable): Page<LectureDto>
     fun searchSemesterLectures(request: SearchQueryDto, pageable: Pageable): Page<LectureDto>
+    fun findLectureRatingsBySnuttIds(snuttIds: List<String>): List<LectureRatingResponse>
 }

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/service/LectureService.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/service/LectureService.kt
@@ -8,6 +8,7 @@ import com.wafflestudio.snuttev.core.domain.evaluation.repository.LectureEvaluat
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureAndSemesterLecturesResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureDto
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureIdResponse
+import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureRatingResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureTakenByUserResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SearchLectureRequest
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SnuttLectureInfo
@@ -116,6 +117,14 @@ class LectureService(
         val lecture = lectureRepository.findByCourseNumberAndInstructor(courseNumber, instructor)
             ?: throw LectureNotFoundException
         return LectureIdResponse(lecture.id!!)
+    }
+
+    fun getLectureIdFromSnuttId(semesterLectureSnuttId: String): Long {
+        return lectureRepository.findBySnuttId(semesterLectureSnuttId)?.id ?: throw LectureNotFoundException
+    }
+
+    fun getLectureRatings(semesterLectureSnuttIds: List<String>): List<LectureRatingResponse> {
+        return lectureRepository.findLectureRatingsBySnuttIds(semesterLectureSnuttIds)
     }
 
     private fun mappingTagsToLectureProperty(request: SearchLectureRequest): SearchQueryDto {

--- a/core/src/main/resources/db/V4__semester_lecture_snutt_id.sql
+++ b/core/src/main/resources/db/V4__semester_lecture_snutt_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE semester_lecture ADD COLUMN snutt_id CHAR(24) DEFAULT NULL;
+ALTER TABLE semester_lecture ADD INDEX semester_lecture_snutt_id_index(snutt_id);


### PR DESCRIPTION
https://www.notion.so/wafflestudio/e09ed2eae36748529353280defa4d61c

### 변경사항
- spring boot 버전 업그레이드
  - batch 5.1.1로 되면서 mongoItemReader deprecated, MongoItemCursorReader와 MongoItemPagingReader? 로 나뉨
  - 커서 리더 사용
- snutt 전달용 강의평점 api 생성
- 기존 ev 강의 id 전달용 api 외에 snutt 학기강의 id (mongo id) 넘겨서 ev id 받는 api 추가