### PR TITLE
snutt 전달용 강의평점 api 생성

### DIFF
--- a/api/src/main/kotlin/com/wafflestudio/snuttev/controller/EvaluationController.kt
+++ b/api/src/main/kotlin/com/wafflestudio/snuttev/controller/EvaluationController.kt
@@ -58,7 +58,7 @@ class EvaluationController(
     @GetMapping("/v1/lectures/{id}/evaluations")
     fun getLectureEvaluations(
         @PathVariable(value = "id") lectureId: Long,
-        @RequestParam("cursor") cursor: String?,
+        @RequestParam cursor: String?,
         @RequestAttribute(value = "UserId") userId: String,
     ): CursorPaginationResponse<EvaluationWithSemesterResponse> {
         return evaluationService.getEvaluationsOfLecture(userId, lectureId, cursor)
@@ -74,7 +74,7 @@ class EvaluationController(
 
     @GetMapping("/v1/evaluations/users/me")
     fun getEvaluationsOfMe(
-        @RequestParam("cursor") cursor: String?,
+        @RequestParam cursor: String?,
         @RequestAttribute(value = "UserId") userId: String,
     ): CursorPaginationResponse<EvaluationWithLectureResponse> {
         return evaluationService.getMyEvaluations(userId, cursor)
@@ -83,7 +83,7 @@ class EvaluationController(
     @GetMapping("/v1/tags/main/{id}/evaluations")
     fun getMainTagEvaluations(
         @PathVariable(value = "id") tagId: Long,
-        @RequestParam("cursor") cursor: String?,
+        @RequestParam cursor: String?,
         @RequestAttribute(value = "UserId") userId: String,
     ): CursorPaginationResponse<EvaluationWithLectureResponse> {
         return evaluationService.getMainTagEvaluations(userId, tagId, cursor)

--- a/api/src/main/kotlin/com/wafflestudio/snuttev/controller/LectureController.kt
+++ b/api/src/main/kotlin/com/wafflestudio/snuttev/controller/LectureController.kt
@@ -51,8 +51,8 @@ class LectureController(
     fun getEvLectureSummaryForSnutt(
         @RequestParam("semesterLectureSnuttIds") semesterLectureSnuttIds: List<String>,
     ): ListResponse<EvLectureSummaryForSnutt> {
-        val lectureRatings = lectureService.getEvLectureSummaryForSnutt(semesterLectureSnuttIds)
-        return ListResponse(lectureRatings)
+        val evLectureSummary = lectureService.getEvLectureSummaryForSnutt(semesterLectureSnuttIds)
+        return ListResponse(evLectureSummary)
     }
 
     @GetMapping("/v1/users/me/lectures/latest")

--- a/api/src/main/kotlin/com/wafflestudio/snuttev/controller/LectureController.kt
+++ b/api/src/main/kotlin/com/wafflestudio/snuttev/controller/LectureController.kt
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.wafflestudio.snuttev.core.common.dto.common.ListResponse
 import com.wafflestudio.snuttev.core.common.dto.common.PaginationResponse
+import com.wafflestudio.snuttev.core.domain.lecture.dto.EvLectureSummaryForSnutt
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureAndSemesterLecturesResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureDto
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureIdResponse
-import com.wafflestudio.snuttev.core.domain.lecture.dto.EvLectureSummaryForSnutt
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureTakenByUserResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SearchLectureRequest
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SnuttLectureInfo

--- a/api/src/main/kotlin/com/wafflestudio/snuttev/controller/LectureController.kt
+++ b/api/src/main/kotlin/com/wafflestudio/snuttev/controller/LectureController.kt
@@ -7,6 +7,7 @@ import com.wafflestudio.snuttev.core.common.dto.common.PaginationResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureAndSemesterLecturesResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureDto
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureIdResponse
+import com.wafflestudio.snuttev.core.domain.lecture.dto.EvLectureSummaryForSnutt
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureTakenByUserResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SearchLectureRequest
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SnuttLectureInfo
@@ -44,6 +45,14 @@ class LectureController(
         @RequestParam("instructor") instructor: String,
     ): LectureIdResponse {
         return lectureService.getLectureIdFromCourseNumber(courseNumber, instructor)
+    }
+
+    @GetMapping("/v1/lectures/snutt-summary")
+    fun getEvLectureSummaryForSnutt(
+        @RequestParam("semesterLectureSnuttIds") semesterLectureSnuttIds: List<String>,
+    ): ListResponse<EvLectureSummaryForSnutt> {
+        val lectureRatings = lectureService.getEvLectureSummaryForSnutt(semesterLectureSnuttIds)
+        return ListResponse(lectureRatings)
     }
 
     @GetMapping("/v1/users/me/lectures/latest")

--- a/api/src/main/kotlin/com/wafflestudio/snuttev/controller/LectureController.kt
+++ b/api/src/main/kotlin/com/wafflestudio/snuttev/controller/LectureController.kt
@@ -42,14 +42,14 @@ class LectureController(
     @GetMapping("/v1/lectures/id")
     fun getLectureId(
         @RequestParam("course_number") courseNumber: String,
-        @RequestParam("instructor") instructor: String,
+        @RequestParam instructor: String,
     ): LectureIdResponse {
         return lectureService.getLectureIdFromCourseNumber(courseNumber, instructor)
     }
 
     @GetMapping("/v1/lectures/snutt-summary")
     fun getEvLectureSummaryForSnutt(
-        @RequestParam("semesterLectureSnuttIds") semesterLectureSnuttIds: List<String>,
+        @RequestParam semesterLectureSnuttIds: List<String>,
     ): ListResponse<EvLectureSummaryForSnutt> {
         val evLectureSummary = lectureService.getEvLectureSummaryForSnutt(semesterLectureSnuttIds)
         return ListResponse(evLectureSummary)
@@ -60,7 +60,7 @@ class LectureController(
         @Parameter(hidden = true)
         @RequestParam("snutt_lecture_info")
         snuttLectureInfoString: String? = "",
-        @RequestParam("filter")
+        @RequestParam
         filter: String?,
         @RequestAttribute(value = "UserId")
         userId: String,

--- a/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
+++ b/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
@@ -136,6 +136,7 @@ class SnuttLectureSyncJobConfig(
                 this.extraInfo = item.remark
                 this.lecture = lecture
                 this.credit = item.credit
+                this.snuttId = item.id
             } ?: SemesterLecture(
                 lecture,
                 item.year,
@@ -145,6 +146,7 @@ class SnuttLectureSyncJobConfig(
                 item.academicYear,
                 item.category,
                 LectureClassification.customValueOf(item.classification)!!,
+                item.id,
             ).also { semesterLecturesMap["${item.courseNumber},${item.instructor},${item.year},${item.semester}"] = it }
         }
     }

--- a/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
+++ b/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
@@ -1,13 +1,11 @@
 package com.wafflestudio.snuttev.sync
 
 import com.wafflestudio.snuttev.core.common.type.LectureClassification
-import com.wafflestudio.snuttev.core.common.util.SemesterUtils
 import com.wafflestudio.snuttev.core.domain.lecture.model.Lecture
 import com.wafflestudio.snuttev.core.domain.lecture.model.SemesterLecture
 import com.wafflestudio.snuttev.core.domain.lecture.repository.LectureRepository
 import com.wafflestudio.snuttev.core.domain.lecture.repository.SemesterLectureRepository
 import com.wafflestudio.snuttev.sync.model.SnuttSemesterLecture
-import com.wafflestudio.snuttev.sync.repository.SnuttSemesterLectureRepository
 import jakarta.persistence.EntityManagerFactory
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.Step

--- a/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
+++ b/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
@@ -16,8 +16,8 @@ import org.springframework.batch.core.repository.JobRepository
 import org.springframework.batch.core.step.builder.StepBuilder
 import org.springframework.batch.item.ItemProcessor
 import org.springframework.batch.item.ItemWriter
-import org.springframework.batch.item.data.MongoItemReader
-import org.springframework.batch.item.data.builder.MongoItemReaderBuilder
+import org.springframework.batch.item.data.MongoCursorItemReader
+import org.springframework.batch.item.data.builder.MongoCursorItemReaderBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
@@ -36,8 +36,6 @@ class SnuttLectureSyncJobConfig(
     private val mongoTemplate: MongoTemplate,
     private val semesterLectureRepository: SemesterLectureRepository,
     private val lectureRepository: LectureRepository,
-    private val semesterUtils: SemesterUtils,
-    private val snuttSemesterLectureRepository: SnuttSemesterLectureRepository,
 ) {
     companion object {
         private const val JOB_NAME = "SYNC_JOB"
@@ -104,12 +102,12 @@ class SnuttLectureSyncJobConfig(
             .build()
     }
 
-    private fun reader(query: Query): MongoItemReader<SnuttSemesterLecture> {
-        return MongoItemReaderBuilder<SnuttSemesterLecture>()
+    private fun reader(query: Query): MongoCursorItemReader<SnuttSemesterLecture> {
+        return MongoCursorItemReaderBuilder<SnuttSemesterLecture>()
             .template(mongoTemplate)
             .collection("lectures").query(query)
-            .sorts(mapOf("courseNumber" to Sort.DEFAULT_DIRECTION))
-            .targetType(SnuttSemesterLecture::class.java).pageSize(CHUNK_SIZE)
+            .sorts(mapOf("_id" to Sort.DEFAULT_DIRECTION))
+            .targetType(SnuttSemesterLecture::class.java)
             .name(this::reader.name)
             .build()
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,12 +4,12 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 import java.io.ByteArrayOutputStream
 
 plugins {
-    id("org.springframework.boot") version "3.1.4" apply false
+    id("org.springframework.boot") version "3.2.4" apply false
     id("io.spring.dependency-management") version "1.1.3"
-    kotlin("jvm") version "1.9.10"
-    kotlin("plugin.spring") version "1.8.21"
-    kotlin("plugin.allopen") version "1.8.21"
-    kotlin("plugin.noarg") version "1.8.21"
+    kotlin("jvm") version "1.9.22"
+    kotlin("plugin.spring") version "1.9.22"
+    kotlin("plugin.allopen") version "1.9.22"
+    kotlin("plugin.noarg") version "1.9.22"
     id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
 }
 

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/dto/LectureResponse.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/dto/LectureResponse.kt
@@ -50,3 +50,9 @@ data class LectureTakenByUserResponse(
     val takenYear: Int,
     val takenSemester: Int,
 )
+
+data class EvLectureSummaryForSnutt(
+    val snuttId: String,
+    val evLectureId: Long,
+    val avgRating: Double?
+)

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/dto/LectureResponse.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/dto/LectureResponse.kt
@@ -54,5 +54,5 @@ data class LectureTakenByUserResponse(
 data class EvLectureSummaryForSnutt(
     val snuttId: String,
     val evLectureId: Long,
-    val avgRating: Double?
+    val avgRating: Double?,
 )

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/model/Lecture.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/model/Lecture.kt
@@ -61,3 +61,8 @@ data class LectureEvaluationSummaryDao(
     val avgLifeBalance: Double?,
     val avgRating: Double?,
 )
+
+data class LectureRatingDao(
+    val id: Long,
+    val avgRating: Double?
+)

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/model/Lecture.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/model/Lecture.kt
@@ -64,5 +64,5 @@ data class LectureEvaluationSummaryDao(
 
 data class LectureRatingDao(
     val id: Long,
-    val avgRating: Double?
+    val avgRating: Double?,
 )

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/model/SemesterLecture.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/model/SemesterLecture.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.Column
 import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
@@ -14,7 +15,10 @@ import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 
 @Entity
-@Table(uniqueConstraints = [UniqueConstraint(columnNames = ["lecture_id", "year", "semester"])])
+@Table(
+    uniqueConstraints = [UniqueConstraint(columnNames = ["lecture_id", "year", "semester"])],
+    indexes = [Index(name = "semester_lecture_snutt_id_index", columnList = "snutt_id")],
+)
 class SemesterLecture(
     @ManyToOne(optional = false, fetch = FetchType.LAZY)
     @JoinColumn(name = "lecture_id", nullable = false)
@@ -36,6 +40,9 @@ class SemesterLecture(
 
     @Convert(converter = LectureClassificationConverter::class)
     var classification: LectureClassification,
+
+    @Column(name = "snutt_id", columnDefinition = "char(24)")
+    var snuttId: String? = null,
 
     @OneToMany(mappedBy = "semesterLecture")
     val evaluations: List<LectureEvaluation> = listOf(),

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/LectureRepository.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/LectureRepository.kt
@@ -2,6 +2,7 @@ package com.wafflestudio.snuttev.core.domain.lecture.repository
 
 import com.wafflestudio.snuttev.core.domain.lecture.model.Lecture
 import com.wafflestudio.snuttev.core.domain.lecture.model.LectureEvaluationSummaryDao
+import com.wafflestudio.snuttev.core.domain.lecture.model.LectureRatingDao
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -22,4 +23,13 @@ interface LectureRepository : JpaRepository<Lecture, Long?>, LectureRepositoryCu
     """,
     )
     fun findLectureWithAvgEvById(id: Long): LectureEvaluationSummaryDao
+
+    @Query(
+        """
+        select new com.wafflestudio.snuttev.core.domain.lecture.model.LectureRatingDao(
+        sl.lecture.id, avg(le.rating)
+        ) from LectureEvaluation le right join le.semesterLecture sl where sl.lecture.id in :ids and le.isHidden = false group by sl.lecture.id 
+        """,
+    )
+    fun findAllRatingsByLectureIds(ids: List<Long>): List<LectureRatingDao>
 }

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/SemesterLectureRepository.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/SemesterLectureRepository.kt
@@ -27,4 +27,7 @@ interface SemesterLectureRepository : JpaRepository<SemesterLecture, Long> {
     fun findAllByLectureIdOrderByYearDescSemesterDesc(lectureId: Long): List<SemesterLectureWithLecture>
 
     fun findByYearAndSemesterAndLecture(year: Int, semester: Int, lecture: Lecture): SemesterLecture?
+
+    @Query("SELECT sl FROM SemesterLecture sl INNER JOIN FETCH Lecture l ON sl.lecture = l WHERE sl.snuttId IN :snuttIds")
+    fun findAllBySnuttIds(snuttIds: List<String>): List<SemesterLecture>
 }

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/service/LectureService.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/service/LectureService.kt
@@ -8,6 +8,7 @@ import com.wafflestudio.snuttev.core.domain.evaluation.repository.LectureEvaluat
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureAndSemesterLecturesResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureDto
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureIdResponse
+import com.wafflestudio.snuttev.core.domain.lecture.dto.EvLectureSummaryForSnutt
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureTakenByUserResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SearchLectureRequest
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SnuttLectureInfo
@@ -116,6 +117,19 @@ class LectureService(
         val lecture = lectureRepository.findByCourseNumberAndInstructor(courseNumber, instructor)
             ?: throw LectureNotFoundException
         return LectureIdResponse(lecture.id!!)
+    }
+
+    fun getEvLectureSummaryForSnutt(semesterLectureSnuttIds: List<String>): List<EvLectureSummaryForSnutt> {
+        val lectures = semesterLectureRepository.findAllBySnuttIds(semesterLectureSnuttIds)
+        val ratingMap = lectureRepository.findAllRatingsByLectureIds(lectures.map { it.lecture.id!! })
+            .associate { it.id to it.avgRating }
+        return lectures.map {
+            EvLectureSummaryForSnutt(
+                snuttId = it.snuttId!!,
+                evLectureId = it.lecture.id!!,
+                avgRating = ratingMap[it.lecture.id!!],
+            )
+        }
     }
 
     private fun mappingTagsToLectureProperty(request: SearchLectureRequest): SearchQueryDto {

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/service/LectureService.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/service/LectureService.kt
@@ -5,10 +5,10 @@ import com.wafflestudio.snuttev.core.common.error.LectureNotFoundException
 import com.wafflestudio.snuttev.core.common.util.SemesterUtils
 import com.wafflestudio.snuttev.core.domain.evaluation.dto.SemesterLectureDto
 import com.wafflestudio.snuttev.core.domain.evaluation.repository.LectureEvaluationRepository
+import com.wafflestudio.snuttev.core.domain.lecture.dto.EvLectureSummaryForSnutt
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureAndSemesterLecturesResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureDto
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureIdResponse
-import com.wafflestudio.snuttev.core.domain.lecture.dto.EvLectureSummaryForSnutt
 import com.wafflestudio.snuttev.core.domain.lecture.dto.LectureTakenByUserResponse
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SearchLectureRequest
 import com.wafflestudio.snuttev.core.domain.lecture.dto.SnuttLectureInfo

--- a/core/src/main/resources/db/V4__semester_lecture_snutt_id.sql
+++ b/core/src/main/resources/db/V4__semester_lecture_snutt_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE semester_lecture ADD COLUMN snutt_id CHAR(24) DEFAULT NULL;
+ALTER TABLE semester_lecture ADD INDEX semester_lecture_snutt_id_index(snutt_id);


### PR DESCRIPTION
https://www.notion.so/wafflestudio/e09ed2eae36748529353280defa4d61c

### 변경사항
- spring boot 버전 업그레이드
  - batch 5.1.1로 되면서 mongoItemReader deprecated, MongoItemCursorReader와 MongoItemPagingReader? 로 나뉨
  - 커서 리더 사용
- snutt 전달용 강의 summary 전달 api 생성 강의 snuttId 받아서 ev lecture 간략정보 전달 ( snuttId = mongoId)
- 강의 snuttId는 마이그레이션 완료