### PR TITLE
snuttId 마다 evLectureId 보내게 수정

### DIFF
--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/dto/LectureResponse.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/dto/LectureResponse.kt
@@ -62,5 +62,5 @@ data class EvLectureSummaryForSnutt(
     val snuttId: String,
     val evLectureId: Long,
     val avgRating: Double?,
-    val evaluationCount: Long
+    val evaluationCount: Long,
 )

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/service/LectureService.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/service/LectureService.kt
@@ -132,16 +132,16 @@ class LectureService(
     }
 
     fun getEvLectureSummaryForSnutt(semesterLectureSnuttIds: List<String>): List<EvLectureSummaryForSnutt> {
-        val snuttIdLectureIdMap = snuttLectureIdMapRepository.findAllWithSemesterLectureBySnuttIdIn(semesterLectureSnuttIds)
-            .associate { it.snuttId to it.semesterLecture.lecture.id!! }
-        val lectureIds = snuttIdLectureIdMap.values
+        val snuttLectureIdMaps = snuttLectureIdMapRepository.findAllWithSemesterLectureBySnuttIdIn(semesterLectureSnuttIds)
+        val lectureIds = snuttLectureIdMaps.map { it.semesterLecture.lecture.id!! }
         val evMap = lectureRepository.findAllRatingsByLectureIds(lectureIds).associateBy { it.id }
-        return snuttIdLectureIdMap.map {
+        return snuttLectureIdMaps.map {
+            val evLectureId = it.semesterLecture.lecture.id!!
             EvLectureSummaryForSnutt(
-                snuttId = it.key,
-                evLectureId = it.value,
-                avgRating = evMap[it.value]?.avgRating,
-                evaluationCount = evMap[it.value]?.count ?: 0L,
+                snuttId = it.snuttId,
+                evLectureId = evLectureId,
+                avgRating = evMap[evLectureId]?.avgRating,
+                evaluationCount = evMap[evLectureId]?.count ?: 0L,
             )
         }
     }

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/service/LectureService.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/service/LectureService.kt
@@ -133,15 +133,15 @@ class LectureService(
 
     fun getEvLectureSummaryForSnutt(semesterLectureSnuttIds: List<String>): List<EvLectureSummaryForSnutt> {
         val snuttIdLectureIdMap = snuttLectureIdMapRepository.findAllWithSemesterLectureBySnuttIdIn(semesterLectureSnuttIds)
-            .associate { it.semesterLecture.lecture.id!! to it.snuttId }
-        val lectureIds = snuttIdLectureIdMap.keys
+            .associate { it.snuttId to it.semesterLecture.lecture.id!! }
+        val lectureIds = snuttIdLectureIdMap.values
         val evMap = lectureRepository.findAllRatingsByLectureIds(lectureIds).associateBy { it.id }
-        return lectureIds.map {
+        return snuttIdLectureIdMap.map {
             EvLectureSummaryForSnutt(
-                snuttId = snuttIdLectureIdMap[it]!!,
-                evLectureId = it,
-                avgRating = evMap[it]?.avgRating,
-                evaluationCount = evMap[it]?.count ?: 0L,
+                snuttId = it.key,
+                evLectureId = it.value,
+                avgRating = evMap[it.value]?.avgRating,
+                evaluationCount = evMap[it.value]?.count ?: 0L,
             )
         }
     }


### PR DESCRIPTION
(시간대가 다른) 같은 교수님의 같은 강의가 v1/lectures/snutt-summary에 여러 개 들어올때 그 중 하나의 snuttId에 대해서만 evLectureId를 응답하는 문제를 수정했습니다