### PR TITLE
snu4t에 강의 평점 동기화

### DIFF
--- a/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
+++ b/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
@@ -37,6 +37,7 @@ class SnuttLectureSyncJobConfig(
     private val semesterLectureRepository: SemesterLectureRepository,
     private val lectureRepository: LectureRepository,
     private val snuttLectureIdMapRepository: SnuttLectureIdMapRepository,
+    private val ratingSyncJob: Job,
 ) {
     companion object {
         private const val JOB_NAME = "SYNC_JOB"
@@ -78,6 +79,7 @@ class SnuttLectureSyncJobConfig(
                     ),
                 ),
             )
+            .next(ratingSyncJobStep(jobRepository))
             .build()
     }
 
@@ -93,6 +95,7 @@ class SnuttLectureSyncJobConfig(
             .toMutableMap()
         return JobBuilder(JOB_NAME, jobRepository)
             .start(customReaderStep(jobRepository, Query()))
+            .next(ratingSyncJobStep(jobRepository))
             .build()
     }
 
@@ -169,6 +172,11 @@ class SnuttLectureSyncJobConfig(
             snuttLectureIdMapRepository.saveAll(items.map { it.snuttLectureIdMap })
         }
     }
+
+    private fun ratingSyncJobStep(jobRepository: JobRepository): Step =
+        StepBuilder(SnuttRatingSyncJobConfig.RATING_SYNC_JOB_NAME, jobRepository)
+            .job(ratingSyncJob)
+            .build()
 }
 
 data class SyncProcessResult(

--- a/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttRatingSyncJobConfig.kt
+++ b/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttRatingSyncJobConfig.kt
@@ -1,0 +1,95 @@
+package com.wafflestudio.snuttev.sync
+
+import com.wafflestudio.snuttev.core.domain.lecture.model.LectureRatingDao
+import com.wafflestudio.snuttev.core.domain.lecture.model.SnuttLectureIdMap
+import com.wafflestudio.snuttev.core.domain.lecture.repository.LectureRepository
+import com.wafflestudio.snuttev.core.domain.lecture.repository.SnuttLectureIdMapRepository
+import com.wafflestudio.snuttev.sync.model.SnuttSemesterLecture
+import jakarta.persistence.EntityManagerFactory
+import org.springframework.batch.core.Job
+import org.springframework.batch.core.Step
+import org.springframework.batch.core.job.builder.JobBuilder
+import org.springframework.batch.core.repository.JobRepository
+import org.springframework.batch.core.step.builder.StepBuilder
+import org.springframework.batch.item.ItemProcessor
+import org.springframework.batch.item.ItemWriter
+import org.springframework.batch.item.data.RepositoryItemReader
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.BulkOperations
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+import org.springframework.orm.jpa.JpaTransactionManager
+
+@Configuration
+@Profile(value = ["!test"])
+class SnuttRatingSyncJobConfig(
+    private val entityManagerFactory: EntityManagerFactory,
+    private val mongoTemplate: MongoTemplate,
+    private val snuttLectureIdMapRepository: SnuttLectureIdMapRepository,
+) {
+    companion object {
+        private const val JOB_NAME = "RATING_SYNC_JOB"
+        private const val CUSTOM_READER_JOB_STEP = JOB_NAME + "_STEP"
+        private const val CHUNK_SIZE = 1000
+    }
+
+    private var lectureIdtoLectureRatingMap: MutableMap<Long, LectureRatingDao> = mutableMapOf()
+
+    @Bean
+    fun ratingSyncJob(job: JobRepository, jobRepository: JobRepository, lectureRepository: LectureRepository): Job {
+        lectureIdtoLectureRatingMap = lectureRepository.findAllRatings().associateBy { it.id }.toMutableMap()
+
+        return JobBuilder(JOB_NAME, jobRepository)
+            .start(customReaderStep(jobRepository))
+            .build()
+    }
+
+    private fun customReaderStep(jobRepository: JobRepository): Step {
+        return StepBuilder(CUSTOM_READER_JOB_STEP, jobRepository)
+            .chunk<SnuttLectureIdMap, Pair<String, LectureRatingDao?>>(
+                CHUNK_SIZE,
+                JpaTransactionManager().apply {
+                    this.entityManagerFactory = this@SnuttRatingSyncJobConfig.entityManagerFactory
+                },
+            )
+            .reader(reader())
+            .processor(processor())
+            .writer(writer())
+            .build()
+    }
+
+    private fun reader(): RepositoryItemReader<SnuttLectureIdMap> {
+        return RepositoryItemReader<SnuttLectureIdMap>().apply {
+            this.setRepository(snuttLectureIdMapRepository)
+            this.setMethodName("findAll")
+            this.setPageSize(CHUNK_SIZE)
+            this.setSort(mapOf("id" to Sort.Direction.ASC))
+        }
+    }
+
+    private fun processor(): ItemProcessor<SnuttLectureIdMap, Pair<String, LectureRatingDao?>> {
+        return ItemProcessor { item ->
+            item.snuttId to lectureIdtoLectureRatingMap[item.semesterLecture.lecture.id!!]
+        }
+    }
+
+    private fun writer(): ItemWriter<Pair<String, LectureRatingDao?>> {
+        return ItemWriter { items ->
+            val bulkOps = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED, SnuttSemesterLecture::class.java)
+            items.forEach {
+                bulkOps.updateOne(
+                    Query(Criteria.where("_id").`is`(it.first)),
+                    Update().set("evInfo.evId", it.second?.id)
+                        .set("evInfo.avgRating", it.second?.avgRating)
+                        .set("evInfo.count", it.second?.count),
+                )
+            }
+            bulkOps.execute()
+        }
+    }
+}

--- a/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttRatingSyncJobConfig.kt
+++ b/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttRatingSyncJobConfig.kt
@@ -35,7 +35,7 @@ class SnuttRatingSyncJobConfig(
     }
 
     @Bean
-    fun ratingSyncJob(job: JobRepository, jobRepository: JobRepository): Job {
+    fun ratingSyncJob(jobRepository: JobRepository): Job {
         return JobBuilder(RATING_SYNC_JOB_NAME, jobRepository)
             .start(customReaderStep(jobRepository))
             .build()

--- a/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttRatingSyncJobConfig.kt
+++ b/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttRatingSyncJobConfig.kt
@@ -4,7 +4,6 @@ import com.wafflestudio.snuttev.core.domain.lecture.model.LectureRatingDao
 import com.wafflestudio.snuttev.core.domain.lecture.model.SnuttLectureIdMap
 import com.wafflestudio.snuttev.core.domain.lecture.repository.LectureRepository
 import com.wafflestudio.snuttev.core.domain.lecture.repository.SnuttLectureIdMapRepository
-import com.wafflestudio.snuttev.sync.model.SnuttSemesterLecture
 import jakarta.persistence.EntityManagerFactory
 import org.springframework.batch.core.Job
 import org.springframework.batch.core.Step
@@ -80,7 +79,7 @@ class SnuttRatingSyncJobConfig(
 
     private fun writer(): ItemWriter<Pair<String, LectureRatingDao?>> {
         return ItemWriter { items ->
-            val bulkOps = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED, SnuttSemesterLecture::class.java)
+            val bulkOps = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED, "lectures")
             items.forEach {
                 bulkOps.updateOne(
                     Query(Criteria.where("_id").`is`(it.first)),

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation("software.amazon.awssdk:secretsmanager:2.20.66")
     implementation("software.amazon.awssdk:sts:2.20.66")
 
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/evaluation/service/EvaluationService.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/evaluation/service/EvaluationService.kt
@@ -37,12 +37,9 @@ import com.wafflestudio.snuttev.core.domain.lecture.model.SemesterLecture
 import com.wafflestudio.snuttev.core.domain.lecture.repository.LectureRepository
 import com.wafflestudio.snuttev.core.domain.lecture.repository.SemesterLectureRepository
 import com.wafflestudio.snuttev.core.domain.lecture.repository.SnuttLectureIdMapRepository
+import com.wafflestudio.snuttev.core.domain.mongo.MongoService
 import com.wafflestudio.snuttev.core.domain.tag.repository.TagRepository
 import org.springframework.dao.DataIntegrityViolationException
-import org.springframework.data.mongodb.core.ReactiveMongoTemplate
-import org.springframework.data.mongodb.core.query.Criteria
-import org.springframework.data.mongodb.core.query.Query
-import org.springframework.data.mongodb.core.query.Update
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -56,8 +53,8 @@ class EvaluationService internal constructor(
     private val evaluationReportRepository: EvaluationReportRepository,
     private val evaluationLikeRepository: EvaluationLikeRepository,
     private val cache: Cache,
-    private val mongoTemplate: ReactiveMongoTemplate,
     private val snuttLectureIdMapRepository: SnuttLectureIdMapRepository,
+    private val mongoService: MongoService,
 ) {
     companion object {
         private const val DEFAULT_PAGE_SIZE = 20
@@ -84,7 +81,7 @@ class EvaluationService internal constructor(
 
         cache.deleteAll(CacheKey.EVALUATIONS_BY_TAG_PAGE)
 
-        updateEvInfoToSnu4t(semesterLecture)
+        updateEvInfosBySemesterLecture(semesterLecture)
 
         return genLectureEvaluationDto(lectureEvaluation)
     }
@@ -285,7 +282,7 @@ class EvaluationService internal constructor(
         }
 
         cache.deleteAll(CacheKey.EVALUATIONS_BY_TAG_PAGE)
-        updateEvInfoToSnu4t(evaluation.semesterLecture)
+        updateEvInfosBySemesterLecture(evaluation.semesterLecture)
 
         val isLiked = evaluationLikeRepository.existsByLectureEvaluationAndUserId(evaluation, userId)
         return EvaluationWithSemesterResponse.of(evaluation, userId, isLiked)
@@ -318,7 +315,7 @@ class EvaluationService internal constructor(
         lectureEvaluation.isHidden = true
 
         cache.deleteAll(CacheKey.EVALUATIONS_BY_TAG_PAGE)
-        updateEvInfoToSnu4t(lectureEvaluation.semesterLecture)
+        updateEvInfosBySemesterLecture(lectureEvaluation.semesterLecture)
     }
 
     fun reportEvaluation(
@@ -403,15 +400,9 @@ class EvaluationService internal constructor(
             isHidden = evaluationReport.isHidden,
         )
 
-    private fun updateEvInfoToSnu4t(semesterLecture: SemesterLecture) {
-        val lectureRatingDao = lectureRepository.findAllRatingsByLectureIds(listOf(semesterLecture.lecture.id!!)).firstOrNull()
-        val snuttId = snuttLectureIdMapRepository.findAllBySemesterLecture(semesterLecture).map { it.snuttId }
-        mongoTemplate.updateMulti(
-            Query(Criteria.where("_id").`in`(snuttId)),
-            Update().set("evInfo.evId", lectureRatingDao?.id)
-                .set("evInfo.avgRating", lectureRatingDao?.avgRating)
-                .set("evInfo.count", lectureRatingDao?.count),
-            "lectures",
-        ).subscribe()
+    private fun updateEvInfosBySemesterLecture(semesterLecture: SemesterLecture) {
+        val evInfo = lectureRepository.findAllRatingsByLectureIds(listOf(semesterLecture.lecture.id!!)).firstOrNull()
+        val snuttIds = snuttLectureIdMapRepository.findAllBySemesterLecture(semesterLecture).map { it.snuttId }
+        mongoService.updateEvInfoToSnuttIds(snuttIds, evInfo)
     }
 }

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/LectureRepository.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/LectureRepository.kt
@@ -32,4 +32,13 @@ interface LectureRepository : JpaRepository<Lecture, Long?>, LectureRepositoryCu
         """,
     )
     fun findAllRatingsByLectureIds(ids: Iterable<Long>): List<LectureRatingDao>
+
+    @Query(
+        """
+        select new com.wafflestudio.snuttev.core.domain.lecture.model.LectureRatingDao(
+        sl.lecture.id, avg(le.rating), count(le.id)
+        ) from LectureEvaluation le right join le.semesterLecture sl where le.isHidden = false group by sl.lecture.id 
+        """,
+    )
+    fun findAllRatings(): List<LectureRatingDao>
 }

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/SnuttLectureIdMapRepository.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/SnuttLectureIdMapRepository.kt
@@ -1,5 +1,6 @@
 package com.wafflestudio.snuttev.core.domain.lecture.repository
 
+import com.wafflestudio.snuttev.core.domain.lecture.model.SemesterLecture
 import com.wafflestudio.snuttev.core.domain.lecture.model.SnuttLectureIdMap
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -8,4 +9,5 @@ interface SnuttLectureIdMapRepository : JpaRepository<SnuttLectureIdMap, Long> {
     @Query("SELECT ttm FROM SnuttLectureIdMap ttm JOIN FETCH ttm.semesterLecture WHERE ttm.snuttId IN :snuttIds")
     fun findAllWithSemesterLectureBySnuttIdIn(snuttIds: List<String>): List<SnuttLectureIdMap>
     fun findBySnuttId(snuttId: String): SnuttLectureIdMap?
+    fun findAllBySemesterLecture(semesterLecture: SemesterLecture): List<SnuttLectureIdMap>
 }

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/mongo/MongoService.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/mongo/MongoService.kt
@@ -1,0 +1,22 @@
+package com.wafflestudio.snuttev.core.domain.mongo
+
+import com.wafflestudio.snuttev.core.domain.lecture.model.LectureRatingDao
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
+import org.springframework.stereotype.Service
+
+@Service
+class MongoService(
+    private val mongoTemplate: ReactiveMongoTemplate,
+) {
+    fun updateEvInfoToSnuttIds(snuttIds: List<String>, evInfo: LectureRatingDao?) =
+        mongoTemplate.updateMulti(
+            Query(Criteria.where("_id").`in`(snuttIds)),
+            Update().set("evInfo.evId", evInfo?.id)
+                .set("evInfo.avgRating", evInfo?.avgRating)
+                .set("evInfo.count", evInfo?.count),
+            "lectures",
+        ).subscribe()
+}


### PR DESCRIPTION
snu4t mongodb에 강의평점 정보를 동기화하는 배치를 만들었고 EvaluationService에서도 snu4t mongodb를 연결해서 강의평 변동 시 같이 업데이트되게 만들었습니다.
만들고 보니 직접 mongo 연결하는게 별로 자연스러운거 같지 않긴 한데 리뷰해주시면 반영하겠습니다.