### PR TITLE
검색 빈 쿼리 들어올 때 에러 방지

### DIFF
--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/LectureRepositoryImpl.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/domain/lecture/repository/LectureRepositoryImpl.kt
@@ -183,6 +183,6 @@ class LectureRepositoryImpl(private val queryFactory: JPAQueryFactory) : Lecture
     }
 
     private fun String.hasKorean(): Boolean {
-        return this.map { it.isHangul() }.reduce { acc, c -> acc || c }
+        return this.any { it.isHangul() }
     }
 }


### PR DESCRIPTION
https://wafflestudio.slack.com/archives/C052DL4F3C0/p1739322507545899

java.lang.UnsupportedOperationException : Empty collection can't be reduced.

쿼리 빈칸일 때 reduce 에러