### PR TITLE
배치에서 snuttLectureIdMap이 업데이트되지 않는 문제 수정

### DIFF
--- a/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
+++ b/batch/src/main/kotlin/com/wafflestudio/snuttev/sync/SnuttLectureSyncJobConfig.kt
@@ -157,6 +157,9 @@ class SnuttLectureSyncJobConfig(
                 item.category,
                 LectureClassification.customValueOf(item.classification)!!,
             ).also { semesterLecturesMap["${item.courseNumber},${item.instructor},${item.year},${item.semester}"] = it }
+            if (snuttLectureIdMap[item.id]?.semesterLecture?.id != semesterLecture.id) {
+                snuttLectureIdMap[item.id]?.semesterLecture = semesterLecture
+            }
             val snuttIdToLecture = snuttLectureIdMap[item.id] ?: SnuttLectureIdMap(
                 item.id,
                 semesterLecture,


### PR DESCRIPTION
강의가 업데이트되어 instructor가 바뀌면 snuttId를 다른 semesterLecture에 연결해야 하는데
기존에는 snuttLectureIdMap에 snuttId 가 같은 강의가 이미 있는 경우 semesterLecture를 변경하지 않는 문제가 있어서 수정했습니다