### PR TITLE
prod 배포 알림을 Slack에서 Discord webhook으로 변경

### DIFF
--- a/.github/workflows/deploy-prod-native.yml
+++ b/.github/workflows/deploy-prod-native.yml
@@ -29,13 +29,11 @@ jobs:
     needs: [deploy-api, deploy-batch]
     runs-on: ubuntu-latest
     steps:
-      - name: Slack Notify
-        uses: rtCamp/action-slack-notify@v2.3.3
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: team-snutt-deploy
-          SLACK_TITLE: NEW RELEASE
-          SLACK_USERNAME: snutt-ev
-          SLACK_ICON: https://user-images.githubusercontent.com/35535636/103177470-2237cb00-48be-11eb-9211-3ffa567c8ac3.png
-          SLACK_MESSAGE: Check <https://argocd.wafflestudio.com|Argo CD> for updated environment
-          SLACK_FOOTER: https://snutt-ev-api.wafflestudio.com/swagger-ui/index.html
+      - name: Discord Notify
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          username: snutt-ev
+          avatar-url: https://user-images.githubusercontent.com/35535636/103177470-2237cb00-48be-11eb-9211-3ffa567c8ac3.png
+          embed-title: NEW RELEASE
+          embed-description: Check [Argo CD](https://argocd.wafflestudio.com) for updated environment

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -29,13 +29,11 @@ jobs:
     needs: [deploy-api, deploy-batch]
     runs-on: ubuntu-latest
     steps:
-      - name: Slack Notify
-        uses: rtCamp/action-slack-notify@v2.3.3
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_CHANNEL: team-snutt-deploy
-          SLACK_TITLE: NEW RELEASE
-          SLACK_USERNAME: snutt-ev
-          SLACK_ICON: https://user-images.githubusercontent.com/35535636/103177470-2237cb00-48be-11eb-9211-3ffa567c8ac3.png
-          SLACK_MESSAGE: Check <https://argocd.wafflestudio.com|Argo CD> for updated environment
-          SLACK_FOOTER: https://snutt-ev-api.wafflestudio.com/swagger-ui/index.html
+      - name: Discord Notify
+        uses: tsickert/discord-webhook@v6.0.0
+        with:
+          webhook-url: ${{ secrets.DISCORD_WEBHOOK }}
+          username: snutt-ev
+          avatar-url: https://user-images.githubusercontent.com/35535636/103177470-2237cb00-48be-11eb-9211-3ffa567c8ac3.png
+          embed-title: NEW RELEASE
+          embed-description: Check [Argo CD](https://argocd.wafflestudio.com) for updated environment


### PR DESCRIPTION
## 변경 사항
- prod 및 prod-native 배포 알림을 Discord webhook으로 변경
- `DISCORD_WEBHOOK` repository secret 사용

## 검증
- `actionlint .github/workflows/deploy-prod.yml .github/workflows/deploy-prod-native.yml`