### PR TITLE
Hibernate enhancer NoSuchMethodError 수정

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,7 +6,9 @@ plugins {
 if (gradle.startParameter.taskNames.none { it.contains("ktlint", ignoreCase = true) }) {
     apply(plugin = "org.hibernate.orm")
     configure<org.hibernate.orm.tooling.gradle.HibernateOrmSpec> {
-        enhancement { enableLazyInitialization = true }
+        // 빈 블록이지만 bytecode enhancement의 opt-in 트리거이므로 제거하면 안 됨.
+        // (enableLazyInitialization 등 세부 옵션은 기본값 true라 명시 불필요)
+        enhancement { }
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,8 +6,6 @@ plugins {
 if (gradle.startParameter.taskNames.none { it.contains("ktlint", ignoreCase = true) }) {
     apply(plugin = "org.hibernate.orm")
     configure<org.hibernate.orm.tooling.gradle.HibernateOrmSpec> {
-        // 빈 블록이지만 bytecode enhancement의 opt-in 트리거이므로 제거하면 안 됨.
-        // (enableLazyInitialization 등 세부 옵션은 기본값 true라 명시 불필요)
         enhancement { }
     }
 }

--- a/core/src/main/kotlin/com/wafflestudio/snuttev/core/common/model/BaseEntity.kt
+++ b/core/src/main/kotlin/com/wafflestudio/snuttev/core/common/model/BaseEntity.kt
@@ -11,13 +11,16 @@ import java.time.LocalDateTime
 
 @MappedSuperclass
 open class BaseEntity(
+    // Kotlin val(final 필드)은 Hibernate bytecode enhancer가 @MappedSuperclass에 writer 메서드를
+    // 생성하지 않아 자식 엔티티의 enhanced 코드가 NoSuchMethodError로 터진다 (HHH-17418 변종).
+    // enhancer가 $$_hibernate_write_*를 생성하도록 var로 선언한다.
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    open val id: Long? = null,
+    open var id: Long? = null,
     @Column(name = "created_at", nullable = false)
-    open val createdAt: LocalDateTime = LocalDateTime.now(),
+    open var createdAt: LocalDateTime = LocalDateTime.now(),
     @field:UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     @OptimisticLock(excluded = true)
-    open val updatedAt: LocalDateTime? = LocalDateTime.now(),
+    open var updatedAt: LocalDateTime? = LocalDateTime.now(),
 )


### PR DESCRIPTION
이해한 만큼만 주절주절썼는데 저도 잘 모르겠어서,, 궁금하신분은 이 description을 클로드에 넣고 이해하시는게 좋으실수도요..


## 문제

- dev 파드(`snutt-dev/snutt-ev:7`, native image)에서 엔티티 `id`를 읽는 API들이 500 발생
  - truffle로 실제로 확인한 API는 GET http://snutt-ev.snutt-dev.svc.cluster.local/v1/tags/main, POST http://snutt-ev.snutt-dev.svc.cluster.local/v1/users/me/lectures/latest
- BaseEntity.$$_hibernate_write_id 라는 메서드를 못 찾은게 원인임. 아래는 전자 API의 예시 

```
java.lang.NoSuchMethodError: com.wafflestudio.snuttev.core.common.model.BaseEntity.$$_hibernate_write_id(java.lang.Long)
    at com.wafflestudio.snuttev.core.domain.tag.model.TagGroup.$$_hibernate_read_id(TagGroup.kt)
    at com.wafflestudio.snuttev.core.common.model.BaseEntity.getId(BaseEntity.kt:16)
```

## 원인

요약: Hibernate 플러그인 버그임


- native image 전환(#134 ) 에서 추가된 `org.hibernate.orm` bytecode enhancement 플러그인(7.2.4.Final)에 버그가 있음
- bytecode enhancement란?
  - = 엔티티의 바이트코드 변조.
  - hibernate는 lazy loading, dirty checking 등의 기능을 구현하기 위해 보통은 runtime에 proxy 클래스의 바이트코드를 만들어내서 사용함(이하 runtime proxy)
  - 그러나 #134 에서 native image로 전환하다보니, 이 runtime proxy를 만드는 게 불가능했음
    - runtime에 인터프리터도 뭣도 없으므로, 만들어낸 바이트코드를 써먹을수가 없기 때문
  - 그래서 컴파일타임에 미리 bytecode를 조작해놔야 함. 그 방법을 bytecode enhancement라고 한다.
    - `org.hibernate.orm` 플러그인을 적용하고, `enhancement {}` 블록을 두는 식으로 적용할 수 있다. 우리도 그렇게 되어있다
- 그러나 이 bytecode enhancement의 결과물에 모순이 있었음
  - bytecode enhancement는 엔티티를 찾아서 필드마다 $$_hibernate_read_{필드명}, $$_hibernate_write_{필드명} 이런 함수를 만듦.
    - 만일 해당 필드가 불변이라면(i.e. java 용어로는 `final`이라면, kotlin 용어로는 `val`이라면) $$_hibernate_write{필드명} 함수는 **생성하지 않는다**
  - 해당 필드에 접근하는 코드가 실행되면, 저 괴상한 함수들이 실행되는 것.
  - 예를들어 TagGroup.$$_hibernate_read_id 의 구현은 이렇게 생겼다고 한다(클로드피셜)

```
    // TagGroup에 생성된 코드 (enhancer가 만든 것)    
    public Long $$_hibernate_read_id() {              
        if ($$_hibernate_getInterceptor() != null) {  
       // Hibernate가 관리 중인 엔티티인가?           
            Long loaded = (Long)                      
  interceptor.readObject(this, "id",                  
  super.$$_hibernate_read_id());                      
            super.$$_hibernate_write_id(loaded);      
           // ← 문제의 호출                           
        }                                             
        return super.$$_hibernate_read_id();          
    }
```

  - 위 코드를 보면 interceptor라는 걸로 lazy loading이든 뭐든 한 후, 그 결과를 $$_hibernate_write_id()를 이용하여 객체의 해당 필드에 다시 담아둔다(dirty checking 때문인듯?)
  - 여기서 문제는: 저 super.$$_hibernate_write_id 가 존재하지 않는데도 불구하고 호출한다는 점.
  - **TagGroup.id는 부모클래스인 BaseEntity에 val으로** 정의되어있어서, $$_hibernate_write_id 없이 $$_hibernate_read_id 만 존재하기 때문
  - Hibernate의 버그로 보임 (https://hibernate.atlassian.net/browse/HHH-17418)
  - 해결은 안됐음

## 해결
- 이 버그가 패치된 버전이 없어서, 그냥 쉽게 id를 var로 변경

## Native image는 2월28일에 배포됐는데 왜 이제야 문제가됐는가?
- 결론은 모른다는 것이며, 최소한 코드로 결정되는 버그는 아닌 것 같다. 빌드 환경 등 다른 영향이 있는 것 같다.
- 클로드의 실험으로는 특정 파일시스템에서 버그가 재현되었음. bytecode enhancement 플러그인이 엔티티 파일을 순회하는 순서가 달라지면 재현된다...?고 하는데 더 파보지 않았습니다 버그같다면 버그같은듯... 클로드 말대로라면 github action runner 등 우리가 모르는 변경으로 인해 갑자기 발생한건가.... 
- 이게 사실이라면 prod가 현재 정상인 건 운이 좋았던거고, 언제라도 이미지 다시 빌드하면 터질 수 있다는 뜻... 일단 dev부터 고쳐봅니다