### PR TITLE
ci: GitOps 이미지 태그를 waffle-world-oci 액션으로 갱신

### DIFF
--- a/.github/workflows/_deploy-native.yml
+++ b/.github/workflows/_deploy-native.yml
@@ -18,8 +18,6 @@ on:
     secrets:
       OCI_AUTH_TOKEN:
         required: true
-      DEPLOYER_APP_ID:
-        required: true
       DEPLOYER_APP_PRIVATE_KEY:
         required: true
 
@@ -67,5 +65,4 @@ jobs:
           image: ${{ env.OCIR_REGISTRY }}/${{ env.OCIR_NAMESPACE }}/${{ env.OCIR_REPOSITORY }}
           tag: ${{ env.IMAGE_TAG }}
           overlay-path: argocd/${{ inputs.ocir_repository }}
-          app-id: ${{ secrets.DEPLOYER_APP_ID }}
           private-key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}

--- a/.github/workflows/_deploy-native.yml
+++ b/.github/workflows/_deploy-native.yml
@@ -10,11 +10,6 @@ on:
         required: true
         type: string
         description: 'Dockerfile path (e.g., api/Dockerfile-native)'
-      update_gitops:
-        required: false
-        type: boolean
-        default: true
-        description: 'Whether to bump the image tag in the GitOps repository.'
     secrets:
       OCI_AUTH_TOKEN:
         required: true
@@ -59,7 +54,6 @@ jobs:
           echo "image=$OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Update GitOps image tag
-        if: ${{ inputs.update_gitops }}
         uses: wafflestudio/waffle-world-oci/.github/actions/update-image@main
         with:
           image: ${{ env.OCIR_REGISTRY }}/${{ env.OCIR_NAMESPACE }}/${{ env.OCIR_REPOSITORY }}

--- a/.github/workflows/_deploy-native.yml
+++ b/.github/workflows/_deploy-native.yml
@@ -10,6 +10,11 @@ on:
         required: true
         type: string
         description: 'Dockerfile path (e.g., api/Dockerfile-native)'
+      update_gitops:
+        required: false
+        type: boolean
+        default: true
+        description: 'Whether to bump the image tag in the GitOps repository.'
     secrets:
       OCI_AUTH_TOKEN:
         required: true
@@ -22,6 +27,10 @@ jobs:
   deploy:
     name: Deploy Native
     runs-on: ubuntu-24.04-arm
+
+    concurrency:
+      group: deploy-${{ inputs.ocir_repository }}
+      cancel-in-progress: true
 
     env:
       IMAGE_TAG: ${{ github.run_number }}
@@ -50,3 +59,13 @@ jobs:
           rm -f .github_token
           docker push $OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG
           echo "image=$OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Update GitOps image tag
+        if: ${{ inputs.update_gitops }}
+        uses: wafflestudio/waffle-world-oci/.github/actions/update-image@main
+        with:
+          image: ${{ env.OCIR_REGISTRY }}/${{ env.OCIR_NAMESPACE }}/${{ env.OCIR_REPOSITORY }}
+          tag: ${{ env.IMAGE_TAG }}
+          overlay-path: argocd/${{ inputs.ocir_repository }}
+          app-id: ${{ secrets.DEPLOYER_APP_ID }}
+          private-key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -18,8 +18,6 @@ on:
     secrets:
       OCI_AUTH_TOKEN:
         required: true
-      DEPLOYER_APP_ID:
-        required: true
       DEPLOYER_APP_PRIVATE_KEY:
         required: true
 
@@ -67,5 +65,4 @@ jobs:
           image: ${{ env.OCIR_REGISTRY }}/${{ env.OCIR_NAMESPACE }}/${{ env.OCIR_REPOSITORY }}
           tag: ${{ env.IMAGE_TAG }}
           overlay-path: argocd/${{ inputs.ocir_repository }}
-          app-id: ${{ secrets.DEPLOYER_APP_ID }}
           private-key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -10,6 +10,11 @@ on:
         required: true
         type: string
         description: 'Dockerfile path (e.g., api/Dockerfile)'
+      update_gitops:
+        required: false
+        type: boolean
+        default: true
+        description: 'Whether to bump the image tag in the GitOps repository.'
     secrets:
       OCI_AUTH_TOKEN:
         required: true
@@ -22,6 +27,10 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-24.04-arm
+
+    concurrency:
+      group: deploy-${{ inputs.ocir_repository }}
+      cancel-in-progress: true
 
     env:
       IMAGE_TAG: ${{ github.run_number }}
@@ -50,3 +59,13 @@ jobs:
           rm -f .github_token
           docker push $OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG
           echo "image=$OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Update GitOps image tag
+        if: ${{ inputs.update_gitops }}
+        uses: wafflestudio/waffle-world-oci/.github/actions/update-image@main
+        with:
+          image: ${{ env.OCIR_REGISTRY }}/${{ env.OCIR_NAMESPACE }}/${{ env.OCIR_REPOSITORY }}
+          tag: ${{ env.IMAGE_TAG }}
+          overlay-path: argocd/${{ inputs.ocir_repository }}
+          app-id: ${{ secrets.DEPLOYER_APP_ID }}
+          private-key: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}

--- a/.github/workflows/_deploy.yml
+++ b/.github/workflows/_deploy.yml
@@ -10,11 +10,6 @@ on:
         required: true
         type: string
         description: 'Dockerfile path (e.g., api/Dockerfile)'
-      update_gitops:
-        required: false
-        type: boolean
-        default: true
-        description: 'Whether to bump the image tag in the GitOps repository.'
     secrets:
       OCI_AUTH_TOKEN:
         required: true
@@ -59,7 +54,6 @@ jobs:
           echo "image=$OCIR_REGISTRY/$OCIR_NAMESPACE/$OCIR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Update GitOps image tag
-        if: ${{ inputs.update_gitops }}
         uses: wafflestudio/waffle-world-oci/.github/actions/update-image@main
         with:
           image: ${{ env.OCIR_REGISTRY }}/${{ env.OCIR_NAMESPACE }}/${{ env.OCIR_REPOSITORY }}

--- a/.github/workflows/deploy-dev-native.yml
+++ b/.github/workflows/deploy-dev-native.yml
@@ -12,7 +12,6 @@ jobs:
       dockerfile: api/Dockerfile-native
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
-      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PRIVATE_KEY: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
   deploy-batch:
@@ -22,5 +21,4 @@ jobs:
       dockerfile: batch/Dockerfile-native
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
-      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PRIVATE_KEY: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,7 +12,6 @@ jobs:
       dockerfile: api/Dockerfile
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
-      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PRIVATE_KEY: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
   deploy-batch:
@@ -22,5 +21,4 @@ jobs:
       dockerfile: batch/Dockerfile
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
-      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PRIVATE_KEY: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -26,5 +26,4 @@ jobs:
       update_gitops: ${{ inputs.update_gitops }}
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
-      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PRIVATE_KEY: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -11,6 +11,11 @@ on:
         description: 'Dockerfile 경로 (예: api/Dockerfile, batch/Dockerfile)'
         required: true
         type: string
+      update_gitops:
+        description: 'GitOps 레포의 이미지 태그를 갱신할지 여부'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   deploy:
@@ -18,6 +23,7 @@ jobs:
     with:
       ocir_repository: ${{ inputs.ocir_repository }}
       dockerfile: ${{ inputs.dockerfile }}
+      update_gitops: ${{ inputs.update_gitops }}
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
       DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}

--- a/.github/workflows/deploy-manual.yml
+++ b/.github/workflows/deploy-manual.yml
@@ -11,11 +11,6 @@ on:
         description: 'Dockerfile 경로 (예: api/Dockerfile, batch/Dockerfile)'
         required: true
         type: string
-      update_gitops:
-        description: 'GitOps 레포의 이미지 태그를 갱신할지 여부'
-        required: false
-        type: boolean
-        default: true
 
 jobs:
   deploy:
@@ -23,7 +18,6 @@ jobs:
     with:
       ocir_repository: ${{ inputs.ocir_repository }}
       dockerfile: ${{ inputs.dockerfile }}
-      update_gitops: ${{ inputs.update_gitops }}
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
       DEPLOYER_APP_PRIVATE_KEY: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}

--- a/.github/workflows/deploy-prod-native.yml
+++ b/.github/workflows/deploy-prod-native.yml
@@ -12,7 +12,6 @@ jobs:
       dockerfile: api/Dockerfile-native
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
-      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PRIVATE_KEY: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
   deploy-batch:
@@ -22,7 +21,6 @@ jobs:
       dockerfile: batch/Dockerfile-native
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
-      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PRIVATE_KEY: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
   notify:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,7 +12,6 @@ jobs:
       dockerfile: api/Dockerfile
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
-      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PRIVATE_KEY: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
   deploy-batch:
@@ -22,7 +21,6 @@ jobs:
       dockerfile: batch/Dockerfile
     secrets:
       OCI_AUTH_TOKEN: ${{ secrets.OCI_AUTH_TOKEN }}
-      DEPLOYER_APP_ID: ${{ secrets.DEPLOYER_APP_ID }}
       DEPLOYER_APP_PRIVATE_KEY: ${{ secrets.DEPLOYER_APP_PRIVATE_KEY }}
 
   notify:


### PR DESCRIPTION
## 변경 사항

이미지를 OCIR에 push한 뒤, `waffle-world-oci`가 노출하는 `update-image` 액션을 호출해서
kustomize overlay의 태그를 올립니다. OCIR push 이벤트를 받아 매니페스트를 치환하던
서버리스 함수(`ocir-image-update`)가 하던 일을 배포 파이프라인 안으로 가져오는 변경입니다.

- overlay 경로는 `argocd/<ocir_repository>`입니다. OCIR 저장소 이름이 이미 GitOps 레포의
  디렉터리 구조와 같아서 워크플로우별로 따로 지정할 필요가 없습니다.
- App id는 액션이 기본값으로 들고 있어서 `DEPLOYER_APP_ID`는 더 이상 쓰이지 않습니다.
  워크플로우에서 배선을 제거했고, `DEPLOYER_APP_PRIVATE_KEY`만 넘깁니다.

## concurrency

빌드와 태그 기록이 더 이상 한 단계가 아니라서, 두 run이 겹치면 나중에 끝난 오래된 run이
최신 태그를 덮어쓸 수 있습니다. OCIR 저장소 단위 concurrency group을 두고
`cancel-in-progress: true`로 했습니다. 취소되는 쪽은 항상 더 오래된 커밋이라 배포될 필요가
없습니다.

group 키를 워크플로우가 아니라 OCIR 저장소로 잡아서, 한 워크플로우 안의 api/batch 두 job이
서로를 직렬화하지 않습니다.

## 선행 조건

#113(액션)은 머지되었습니다. **#130(snutt-ev overlay)을 먼저 머지해야 합니다.** overlay의
`kustomization.yaml`이 없으면 액션이 실패합니다.

`DEPLOYER_APP_PRIVATE_KEY`는 이미 등록되어 있습니다. 다만 2026-03 이후 사용되지 않아서,
값이 현재 App(`waffle-image-update`, id 2842871)과 맞는지는 첫 배포에서 확인이 필요합니다.
